### PR TITLE
Do not compile zimBench on Windows.

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -3,9 +3,12 @@ executable('zimsearch', 'zimSearch.cpp',
   dependencies: libzim_dep,
   install: true)
 
-executable('zimbench', 'zimBench.cpp',
-  dependencies: [libzim_dep, rt_dep],
-  install: true)
+# [FIXME] There are some problem with clock_gettime and mingw.
+if target_machine.system() == 'windows'
+  executable('zimbench', 'zimBench.cpp',
+    dependencies: [libzim_dep, rt_dep],
+    install: true)
+endif
 
 executable('zimdump', 'zimDump.cpp',
   dependencies: libzim_dep,


### PR DESCRIPTION
There are some issues on the CI and mingw with clock_gettime implementation
not being found.
We don't use zimBench and we need to do a release so let's deactivate for
now.