### PR TITLE
Dump nested subdirectories

### DIFF
--- a/src/zimdump.cpp
+++ b/src/zimdump.cpp
@@ -341,9 +341,9 @@ void write_to_error_directoy(const std::string& base, const std::string relpath,
 inline void write_to_file(const std::string &base, const std::string& path, const char* data, ssize_t size) {
     std::string fullpath = base + path;
 #ifdef _WIN32
-    auto needed_size = MultiByteToWideChar(CP_UTF8, 0, path.data(), path.size(), NULL, 0);
+    auto needed_size = MultiByteToWideChar(CP_UTF8, 0, fullpath.data(), fullpath.size(), NULL, 0);
     std::wstring wpath(needed_size, 0);
-    MultiByteToWideChar(CP_UTF8, 0, path.data(), path.size(), &wpath[0], needed_size);
+    MultiByteToWideChar(CP_UTF8, 0, fullpath.data(), fullpath.size(), &wpath[0], needed_size);
     auto fd = _wopen(wpath.c_str(), _O_WRONLY | _O_CREAT | _O_TRUNC, S_IWRITE);
 #else
     auto fd = open(fullpath.c_str(), O_WRONLY | O_CREAT | O_TRUNC,

--- a/src/zimdump.cpp
+++ b/src/zimdump.cpp
@@ -334,9 +334,7 @@ void write_to_error_directory(const std::string& base, const std::string relpath
 
 #ifdef _WIN32
     auto fullpath = std::string(base + ERRORSDIR + url);
-    auto needed_size = MultiByteToWideChar(CP_UTF8, 0, fullpath.data(), fullpath.size(), NULL, 0);
-    std::wstring wpath(needed_size, 0);
-    MultiByteToWideChar(CP_UTF8, 0, fullpath.data(), fullpath.size(), &wpath[0], needed_size);
+    std::wstring wpath = converter.from_bytes(fullpath);
     auto fd = _wopen(wpath.c_str(), _O_WRONLY | _O_CREAT | _O_TRUNC, S_IWRITE);
 
     if (fd == -1) {
@@ -362,9 +360,7 @@ void write_to_error_directory(const std::string& base, const std::string relpath
 inline void write_to_file(const std::string &base, const std::string& path, const char* data, ssize_t size) {
     std::string fullpath = base + path;
 #ifdef _WIN32
-    auto needed_size = MultiByteToWideChar(CP_UTF8, 0, fullpath.data(), fullpath.size(), NULL, 0);
-    std::wstring wpath(needed_size, 0);
-    MultiByteToWideChar(CP_UTF8, 0, fullpath.data(), fullpath.size(), &wpath[0], needed_size);
+    std::wstring wpath = converter.from_bytes(fullpath);
     auto fd = _wopen(wpath.c_str(), _O_WRONLY | _O_CREAT | _O_TRUNC, S_IWRITE);
 #else
     auto fd = open(fullpath.c_str(), O_WRONLY | O_CREAT | O_TRUNC,

--- a/src/zimdump.cpp
+++ b/src/zimdump.cpp
@@ -72,7 +72,7 @@ inline static void createdir(const std::string &path, const std::string &base)
 
 static bool isReservedUrlChar(const char c)
 {
-    constexpr std::array<char, 10> reserved = {{';', ',', '/', '?', ':',
+    constexpr std::array<char, 10> reserved = {{';', ',', '?', ':',
                                                '@', '&', '=', '+', '$' }};
 
     return std::any_of(reserved.begin(), reserved.end(),
@@ -87,8 +87,8 @@ static bool needsEscape(const char c, const bool encodeReserved)
   if (isReservedUrlChar(c))
     return encodeReserved;
 
-  constexpr std::array<char, 9> noNeedEscape = {{'-', '_', '.', '!', '~',
-                                                '*', '\'', '(', ')' }};
+  constexpr std::array<char, 10> noNeedEscape = {{'-', '_', '.', '!', '~',
+                                                '*', '\'', '(', ')', '/' }};
 
   return not std::any_of(noNeedEscape.begin(), noNeedEscape.end(),
                          [&c] (const char &elem) { return elem == c; } );

--- a/src/zimdump.cpp
+++ b/src/zimdump.cpp
@@ -44,7 +44,7 @@
 #include <unistd.h>
 #endif
 
-#define ERRORSDIR "_errordir/"
+#define ERRORSDIR "_exceptions/"
 
 std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
 
@@ -353,6 +353,8 @@ void write_to_error_directory(const std::string& base, const std::string relpath
     if (stream.fail() || stream.bad())
     {
         std::cerr << "Error writing file to errors dir. " << (base + ERRORSDIR + url) << std::endl;
+    }else {
+        std::cerr << "Wrote " << (base + relpath) << " to " << (base + ERRORSDIR + url) << std::endl;
     }
 #endif
 }
@@ -367,12 +369,10 @@ inline void write_to_file(const std::string &base, const std::string& path, cons
                               S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 #endif
     if (fd == -1) {
-        std::cerr << "Error opening file " + fullpath + " cause: " + ::strerror(errno) << std::endl;
         write_to_error_directory(base, path, data, size);
         return ;
     }
     if (write(fd, data, size) != size) {
-      std::cerr << "Failed writing: " << fullpath << " - " << ::strerror(errno) << std::endl;
       write_to_error_directory(base, path, data, size);
     }
     close(fd);

--- a/src/zimdump.cpp
+++ b/src/zimdump.cpp
@@ -442,10 +442,9 @@ void ZimDumper::dumpFiles(const std::string& directory, bool symlinkdump)
         {
             auto encodedurl = urlEncode(redirectUrl, true);
             std::ostringstream ss;
-            ss << ("<meta http-equiv=\"refresh\" content=\"0\"; url=\"" +
-                    encodedurl + "\" />");
-            ss << ("<script type=\"text/javascript\"> window.location.href = \"" +
-                    encodedurl + "\"</script>");
+
+            ss << "<!DOCTYPE html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\" />";
+            ss << "<meta http-equiv=\"refresh\" content=\"0;url=" + encodedurl + "\" /><head><body></body></html>";
             auto content = ss.str();
             write_to_file(directory + SEPARATOR, relative_path, content.c_str(), content.size());
         } else {

--- a/src/zimdump.cpp
+++ b/src/zimdump.cpp
@@ -444,9 +444,12 @@ void ZimDumper::dumpFiles(const std::string& directory, bool symlinkdump)
         std::string redirectUrl = redirectArticle.getUrl();
         if (symlinkdump == false && redirectArticle.getMimeType() == "text/html")
         {
+            auto encodedurl = urlEncode(redirectUrl, true);
             std::ostringstream ss;
             ss << ("<meta http-equiv=\"refresh\" content=\"0\"; url=\"" +
-                    urlEncode(redirectUrl, true) + "\" />");
+                    encodedurl + "\" />");
+            ss << ("<script type=\"text/javascript\"> window.location.href = \"" +
+                    encodedurl + "\"</script>");
             auto content = ss.str();
             write_to_file(directory + SEPARATOR, relative_path, content.c_str(), content.size());
         } else {


### PR DESCRIPTION
Dumps the nested subdirectories for non-A namespace articles.

```
├── -
│   ├── favicon
│   ├── j
│   │   └── js_modules
│   │       ├── article_list_home.js
│   │       ├── ext.cite.ux-enhancements.js
│   │       ├── ext.kartographer.link.js
│   │       ├── ext.kartographer.staticframe.js

```