### PR TITLE
Adapt to new libzim api.

### DIFF
--- a/src/zimdump.cpp
+++ b/src/zimdump.cpp
@@ -110,7 +110,7 @@ void ZimDumper::printNsInfo(char ch)
 
 void ZimDumper::locateArticle(zim::size_type idx)
 {
-  pos = zim::File::const_iterator(&file, idx);
+  pos = zim::File::const_iterator(&file, idx, zim::File::const_iterator::UrlIterator);
 }
 
 void ZimDumper::findArticle(char ns, const char* expr, bool title)


### PR DESCRIPTION
New api doesn't provide a default iterator order anymore.

need openzim/libzim#318