### PR TITLE
Use double braces to initialize std::array.

### DIFF
--- a/src/zimdump.cpp
+++ b/src/zimdump.cpp
@@ -44,8 +44,8 @@
 
 static bool isReservedUrlChar(const char c)
 {
-    constexpr std::array<char, 10> reserved = {';', ',', '/', '?', ':',
-                                               '@', '&', '=', '+', '$' };
+    constexpr std::array<char, 10> reserved = {{';', ',', '/', '?', ':',
+                                               '@', '&', '=', '+', '$' }};
 
     return std::any_of(reserved.begin(), reserved.end(),
                        [&c] (const char &elem) { return elem == c; } );
@@ -59,8 +59,8 @@ static bool needsEscape(const char c, const bool encodeReserved)
   if (isReservedUrlChar(c))
     return encodeReserved;
 
-  constexpr std::array<char, 9> noNeedEscape = {'-', '_', '.', '!', '~',
-                                                '*', '\'', '(', ')' };
+  constexpr std::array<char, 9> noNeedEscape = {{'-', '_', '.', '!', '~',
+                                                '*', '\'', '(', ')' }};
 
   return not std::any_of(noNeedEscape.begin(), noNeedEscape.end(),
                          [&c] (const char &elem) { return elem == c; } );

--- a/src/zimdump.cpp
+++ b/src/zimdump.cpp
@@ -36,6 +36,7 @@
 #ifdef _WIN32
 # define SEPARATOR "\\"
 # include <io.h>
+# include <windows.h>
 #else
 # define SEPARATOR "/"
 # include <unistd.h>


### PR DESCRIPTION
std::array will be initialize to an array of 10 elements (0) with
`{10, 0}`.
To initialize it with 2 elements (10 and 0), we use a double braces
`{{10, 0}}`.

To avoid mistake xcode genere a waring and as we are using `-Werror` it
breaks compilation.
(gcc remove this warnig because it was too anoying).
See https://bugs.llvm.org/show_bug.cgi?id=21629