### PR TITLE
Add test/ subdirectory with stub of autotests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -62,3 +62,4 @@ if with_writer
 endif
 
 subdir('src')
+subdir('test')

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,0 +1,22 @@
+gtest_dep = dependency('gtest', main:true, fallback:['gtest', 'gtest_main_dep'], required:false)
+
+tests = [
+    'zimwriterfs-article'
+]
+
+zimwriter_srcs = [  '../src/zimwriterfs/article.cpp',
+                    '../src/zimwriterfs/tools.cpp',
+                    '../src/zimwriterfs/zimcreatorfs.cpp',
+                    '../src/zimwriterfs/mimetypecounter.cpp',
+                    '../src/tools.cpp']
+
+if gtest_dep.found() and not meson.is_cross_build()
+    foreach test_name : tests
+
+        test_exe = executable(test_name, [test_name+'.cpp'] + zimwriter_srcs,
+                              dependencies : [gtest_dep, libzim_dep, gumbo_dep, magic_dep, zlib_dep],
+                              build_rpath : '$ORIGIN')
+
+        test(test_name, test_exe, timeout : 60)
+    endforeach
+endif

--- a/test/zimwriterfs-article.cpp
+++ b/test/zimwriterfs-article.cpp
@@ -1,0 +1,48 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#include "../src/zimwriterfs/article.h"
+
+#include "gtest/gtest.h"
+#include <magic.h>
+
+// stub from zimwriterfs.cpp
+std::string directoryPath = ".";
+bool isVerbose() { return true; }
+bool inflateHtmlFlag = false;
+bool uniqueNamespace = false;
+magic_t magic;
+
+namespace
+{
+class ArticleTest : public ::testing::Test
+{
+public:
+  ArticleTest() {
+    magic = magic_open(MAGIC_MIME);
+    magic_load(magic, NULL);
+  }
+};
+
+TEST(ArticleTest, Metadata)
+{
+  MetadataDateArticle article;
+
+  ASSERT_FALSE(article.isDeleted());
+}
+
+}  // namespace


### PR DESCRIPTION
Related to #98 (10% of fix)

Adding stub for autotests directory with two empty (sucessful) tests.

Then this stub will be expanded with real tests for 'zimwriterfs', 'zimcheck' and other tools.

It's inspired by libzim/test directory