### PR TITLE
Update 'zimwriterfs' upstream source URL in documentation

### DIFF
--- a/debian/man/zimwriterfs.1
+++ b/debian/man/zimwriterfs.1
@@ -66,4 +66,4 @@ custom (version independent) identifier for the content
 zimwriterfs \fB\-\-welcome\fR=\fI\,index\/\fR.html \fB\-\-favicon\fR=\fI\,m\/\fR/favicon.png \fB\-\-language\fR=\fI\,fra\/\fR \fB\-\-title\fR=\fI\,foobar\/\fR \fB\-\-description\fR=\fI\,mydescription\/\fR \fB\-\-creator\fR=\fI\,Wikipedia\fR \fB\-\-publisher\fR=\fI\,Kiwix\/\fR ./my_project_html_directory my_project.zim
 .SH REPORTING BUGS
 .TP
-Report bugs to <https://github.com/openzim/zimwriterfs>.
+Report bugs to <https://github.com/openzim/zim-tools>.

--- a/src/zimwriterfs/zimwriterfs.cpp
+++ b/src/zimwriterfs/zimwriterfs.cpp
@@ -159,7 +159,7 @@ void usage()
   std::cout << std::endl;
 
   std::cout << "Documentation:" << std::endl;
-  std::cout << "\tzimwriterfs source code: https://github.com/openzim/zimwriterfs"
+  std::cout << "\tzimwriterfs source code: https://github.com/openzim/zim-tools"
             << std::endl;
   std::cout << "\tZIM format: https://openzim.org" << std::endl;
   std::cout << std::endl;


### PR DESCRIPTION
Related to #92 : update man page and 'zimwriterfs --help' output.