### PR TITLE
Remove circular dependency tools and zimwriterfs

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -42,8 +42,6 @@
 #endif
 
 
-extern bool uniqueNamespace;
-
 
 unsigned int getFileSize(const std::string& path)
 {
@@ -272,7 +270,7 @@ void stripTitleInvalidChars(std::string& str)
   replaceStringInPlace(str, "\u202C", "");
 }
 
-std::string getNamespaceForMimeType(const std::string& mimeType)
+std::string getNamespaceForMimeType(const std::string& mimeType, bool uniqueNamespace)
 {
   if (uniqueNamespace || mimeType.find("text") == 0 || mimeType.empty()) {
     if (uniqueNamespace || mimeType.find("text/html") == 0

--- a/src/tools.h
+++ b/src/tools.h
@@ -25,7 +25,7 @@
 #include <string>
 
 std::string getMimeTypeForFile(const std::string& filename);
-std::string getNamespaceForMimeType(const std::string& mimeType);
+std::string getNamespaceForMimeType(const std::string& mimeType, bool uniqueNamespace);
 std::string getFileContent(const std::string& path);
 unsigned int getFileSize(const std::string& path);
 std::string decodeUrl(const std::string& encodedUrl);
@@ -35,7 +35,7 @@ bool fileExists(const std::string& path);
 std::string removeLastPathElement(const std::string& path,
                                   const bool removePreSeparator,
                                   const bool removePostSeparator);
-std::string computeNewUrl(const std::string& aid, const std::string& baseUrl, const std::string& targetUrl);
+std::string computeNewUrl(const std::string& aid, const std::string& baseUrl, const std::string& targetUrl, const bool uniqueNs);
 
 std::string base64_encode(unsigned char const* bytes_to_encode,
                           unsigned int in_len);
@@ -55,4 +55,4 @@ std::string removeAccents(const std::string& text);
 
 void remove_all(const std::string& path);
 
-#endif  // OPENZIM_TOOLS_H
+#endif  // OPENZIM_TOOLS_H

--- a/src/zimwriterfs/article.cpp
+++ b/src/zimwriterfs/article.cpp
@@ -72,8 +72,9 @@ void FileArticle::readData() const
   dataRead = true;
 }
 
-FileArticle::FileArticle(const std::string& path, const bool detectRedirects)
-    : dataRead(false)
+FileArticle::FileArticle(const std::string& path, bool uniqueNs, const bool detectRedirects)
+    : dataRead(false) ,
+      uniqueNs(uniqueNs)
 {
   invalid = false;
 
@@ -83,7 +84,7 @@ FileArticle::FileArticle(const std::string& path, const bool detectRedirects)
   mimeType = getMimeTypeForFile(url);
 
   /* namespace */
-  ns = getNamespaceForMimeType(mimeType)[0];
+  ns = getNamespaceForMimeType(mimeType, uniqueNs)[0];
 
   /* HTML specific code */
   if ( mimeType.find("text/html") != std::string::npos
@@ -190,7 +191,7 @@ void FileArticle::parseAndAdaptHtml(bool detectRedirects)
         && target.substr(0, 5) != "data:") {
       replaceStringInPlace(data,
                            "\"" + target + "\"",
-                           "\"" + computeNewUrl(url, longUrl, target) + "\"");
+                           "\"" + computeNewUrl(url, longUrl, target, uniqueNs) + "\"");
     }
   }
   gumbo_destroy_output(&kGumboDefaultOptions, output);
@@ -260,7 +261,7 @@ void FileArticle::adaptCss() {
         replaceStringInPlaceOnce(
             data,
             startDelimiter + url + endDelimiter,
-            startDelimiter + computeNewUrl(this->url, longUrl, path) + endDelimiter);
+            startDelimiter + computeNewUrl(this->url, longUrl, path, uniqueNs) + endDelimiter);
       }
     }
   }

--- a/src/zimwriterfs/article.h
+++ b/src/zimwriterfs/article.h
@@ -122,6 +122,7 @@ class FileArticle : public Article
   mutable std::string data;
   mutable bool dataRead;
   bool invalid;
+  bool uniqueNs;
   std::string _getFilename() const;
   void readData() const;
   void parseAndAdaptHtml(bool detectRedirects);
@@ -129,6 +130,7 @@ class FileArticle : public Article
 
  public:
   explicit FileArticle(const std::string& path,
+                       bool uniqueNs,
                        const bool detectRedirects = true);
   virtual zim::Blob getData() const;
   virtual bool isLinktarget() const { return false; }

--- a/src/zimwriterfs/tools.cpp
+++ b/src/zimwriterfs/tools.cpp
@@ -323,12 +323,12 @@ inline std::string removeLocalTagAndParameters(const std::string& url)
   return retVal;
 }
 
-std::string computeNewUrl(const std::string& aid, const std::string& baseUrl, const std::string& targetUrl)
+std::string computeNewUrl(const std::string& aid, const std::string& baseUrl, const std::string& targetUrl, const bool uniqueNs)
 {
   std::string filename = computeAbsolutePath(aid, targetUrl);
   std::string targetMimeType
       = getMimeTypeForFile(decodeUrl(removeLocalTagAndParameters(filename)));
   std::string newUrl
-      = "/" + getNamespaceForMimeType(targetMimeType) + "/" + filename;
+      = "/" + getNamespaceForMimeType(targetMimeType, uniqueNs) + "/" + filename;
   return computeRelativePath(baseUrl, newUrl);
 }

--- a/src/zimwriterfs/zimcreatorfs.cpp
+++ b/src/zimwriterfs/zimcreatorfs.cpp
@@ -148,7 +148,7 @@ void ZimCreatorFS::addMetadata(const std::string& metadata, const std::string& c
 
 void ZimCreatorFS::addArticle(const std::string& path)
 {
-  auto farticle = std::make_shared<FileArticle>(path);
+  auto farticle = std::make_shared<FileArticle>(path, uniqueNamespace);
   if (farticle->isInvalid()) {
     return;
   }

--- a/src/zimwriterfs/zimcreatorfs.h
+++ b/src/zimwriterfs/zimcreatorfs.h
@@ -38,9 +38,10 @@ class IHandler
 class ZimCreatorFS : public zim::writer::Creator
 {
  public:
-  ZimCreatorFS(std::string mainPage, bool verbose)
+  ZimCreatorFS(std::string mainPage, bool verbose, bool uniqueNamespace)
     : zim::writer::Creator(verbose),
-      mainPage(mainPage) {}
+      mainPage(mainPage),
+      uniqueNamespace(uniqueNamespace){}
   virtual ~ZimCreatorFS() = default;
   virtual zim::writer::Url getMainUrl() const;
   virtual void add_customHandler(IHandler* handler);
@@ -55,6 +56,7 @@ class ZimCreatorFS : public zim::writer::Creator
  private:
   std::vector<IHandler*> articleHandlers;
   std::string mainPage;
+  bool uniqueNamespace;
 };
 
 #endif  // OPENZIM_ZIMWRITERFS_ARTICLESOURCE_H

--- a/src/zimwriterfs/zimwriterfs.cpp
+++ b/src/zimwriterfs/zimwriterfs.cpp
@@ -328,7 +328,7 @@ int main(int argc, char** argv)
     tags += ";_ftindex"; // For backward compatibility
   }
 
-  ZimCreatorFS zimCreator(welcome, isVerbose());
+  ZimCreatorFS zimCreator(welcome, isVerbose(), uniqueNamespace);
 
   zimCreator.setMinChunkSize(minChunkSize);
   zimCreator.setIndexing(!withoutFTIndex, language);


### PR DESCRIPTION
The global variable uniqueNamespace was creating a bidirectional dependency between tools.h and
zimwriterfs code. This was making impossible to use tools.h in other applications such as zimcheck