### PR TITLE
Issue #98: add tests for src/zimwriterfs classes

### DIFF
--- a/src/tools.h
+++ b/src/tools.h
@@ -25,7 +25,7 @@
 #include <string>
 #include <vector>
 
-std::string getMimeTypeForFile(const std::string& filename);
+std::string getMimeTypeForFile(const std::string& basedir, const std::string& filename);
 std::string getNamespaceForMimeType(const std::string& mimeType, bool uniqueNamespace);
 std::string getFileContent(const std::string& path);
 unsigned int getFileSize(const std::string& path);
@@ -33,8 +33,6 @@ std::string decodeUrl(const std::string& encodedUrl);
 std::string computeAbsolutePath(const std::string& path,
                                 const std::string& relativePath);
 bool fileExists(const std::string& path);
-
-std::string computeNewUrl(const std::string& aid, const std::string& baseUrl, const std::string& targetUrl, const bool uniqueNs);
 
 std::string base64_encode(unsigned char const* bytes_to_encode,
                           unsigned int in_len);
@@ -67,4 +65,4 @@ int adler32(std::string buf);
 std::string normalize_link(const std::string& input, const std::string& baseUrl);
 
 
-#endif  // OPENZIM_TOOLS_H
+#endif  // OPENZIM_TOOLS_H

--- a/src/zimwriterfs/article.cpp
+++ b/src/zimwriterfs/article.cpp
@@ -72,13 +72,13 @@ void FileArticle::readData() const
   dataRead = true;
 }
 
-FileArticle::FileArticle(const std::string& path, bool uniqueNs, const bool detectRedirects)
+FileArticle::FileArticle(const std::string& full_path, bool uniqueNs, const bool detect_html_redirects)
     : dataRead(false) ,
       uniqueNs(uniqueNs)
 {
   invalid = false;
 
-  url = path.substr(directoryPath.size() + 1);
+  url = full_path.substr(directoryPath.size() + 1);
 
   /* mime-type */
   mimeType = getMimeTypeForFile(url);
@@ -93,7 +93,7 @@ FileArticle::FileArticle(const std::string& path, bool uniqueNs, const bool dete
   }
 
   if ( mimeType.find("text/html") != std::string::npos ) {
-    parseAndAdaptHtml(detectRedirects);
+    parseAndAdaptHtml(detect_html_redirects);
   } else if (mimeType.find("text/css") != std::string::npos) {
     adaptCss();
   }

--- a/src/zimwriterfs/article.h
+++ b/src/zimwriterfs/article.h
@@ -27,6 +27,8 @@
 
 extern std::string favicon;
 
+class ZimCreatorFS;
+
 class Article : public zim::writer::Article
 {
  protected:
@@ -120,10 +122,10 @@ class MetadataDateArticle : public MetadataArticle
 class FileArticle : public Article
 {
  private:
+  const ZimCreatorFS *creator;
   mutable std::string data;
   mutable bool dataRead;
   bool invalid;
-  bool uniqueNs;
   std::string _getFilename() const;
   void readData() const;
   void parseAndAdaptHtml(bool detectRedirects);
@@ -131,8 +133,8 @@ class FileArticle : public Article
 
  public:
   //! Must be initialized with full file path
-  explicit FileArticle(const std::string& full_path,
-                       bool uniqueNs,
+  explicit FileArticle(const ZimCreatorFS *creator,
+                       const std::string& full_path,
                        const bool detect_html_redirects = true);
   virtual zim::Blob getData() const;
   virtual bool isLinktarget() const { return false; }
@@ -149,7 +151,8 @@ class FileArticle : public Article
 class RedirectArticle : public Article
 {
  public:
-  explicit RedirectArticle(char ns,
+  explicit RedirectArticle(const ZimCreatorFS *creator,
+                           char ns,
                            const std::string& url,
                            const std::string& title,
                            const zim::writer::Url& redirectUrl);
@@ -159,6 +162,8 @@ class RedirectArticle : public Article
   virtual bool isDeleted() const { return false; }
   virtual zim::size_type getSize() const { return 0; }
   virtual std::string getFilename() const  { return ""; }
+private:
+  const ZimCreatorFS *creator;
 };
 
 #endif  // OPENZIM_ZIMWRITERFS_ARTICLE_H

--- a/src/zimwriterfs/article.h
+++ b/src/zimwriterfs/article.h
@@ -85,6 +85,7 @@ class SimpleMetadataArticle : public MetadataArticle
   }
 };
 
+/// This class creates a redirect entry to image/png favicon
 class MetadataFaviconArticle : public MetadataArticle
 {
  private:
@@ -129,17 +130,22 @@ class FileArticle : public Article
   void adaptCss();
 
  public:
-  explicit FileArticle(const std::string& path,
+  //! Must be initialized with full file path
+  explicit FileArticle(const std::string& full_path,
                        bool uniqueNs,
-                       const bool detectRedirects = true);
+                       const bool detect_html_redirects = true);
   virtual zim::Blob getData() const;
   virtual bool isLinktarget() const { return false; }
   virtual bool isDeleted() const { return false; }
   virtual zim::size_type getSize() const;
+
+  //! Returns full filename; or empty string if content already read from the file
   virtual std::string getFilename() const;
+
   virtual bool isInvalid() const;
 };
 
+/// Redirect entry from user-supplied file
 class RedirectArticle : public Article
 {
  public:

--- a/src/zimwriterfs/tools.cpp
+++ b/src/zimwriterfs/tools.cpp
@@ -114,7 +114,6 @@ static std::map<std::string, std::string> extMimeTypes = _create_extMimeTypes();
 
 static std::map<std::string, std::string> fileMimeTypes;
 
-extern std::string directoryPath;
 extern bool inflateHtmlFlag;
 
 extern magic_t magic;
@@ -269,7 +268,7 @@ void getLinks(GumboNode* node, std::map<std::string, bool>& links)
   }
 }
 
-std::string getMimeTypeForFile(const std::string& filename)
+std::string getMimeTypeForFile(const std::string &directoryPath, const std::string& filename)
 {
   std::string mimeType;
 
@@ -301,34 +300,4 @@ std::string getMimeTypeForFile(const std::string& filename)
   } else {
     return mimeType;
   }
-}
-
-inline std::string removeLocalTagAndParameters(const std::string& url)
-{
-  std::string retVal = url;
-  std::size_t found;
-
-  /* Remove URL arguments */
-  found = retVal.find("?");
-  if (found != std::string::npos) {
-    retVal = retVal.substr(0, found);
-  }
-
-  /* Remove local tag */
-  found = retVal.find("#");
-  if (found != std::string::npos) {
-    retVal = retVal.substr(0, found);
-  }
-
-  return retVal;
-}
-
-std::string computeNewUrl(const std::string& aid, const std::string& baseUrl, const std::string& targetUrl, const bool uniqueNs)
-{
-  std::string filename = computeAbsolutePath(aid, targetUrl);
-  std::string targetMimeType
-      = getMimeTypeForFile(decodeUrl(removeLocalTagAndParameters(filename)));
-  std::string newUrl
-      = "/" + getNamespaceForMimeType(targetMimeType, uniqueNs) + "/" + filename;
-  return computeRelativePath(baseUrl, newUrl);
 }

--- a/src/zimwriterfs/zimcreatorfs.cpp
+++ b/src/zimwriterfs/zimcreatorfs.cpp
@@ -53,10 +53,10 @@ void ZimCreatorFS::add_redirectArticles_from_file(const std::string& path)
     }
 
     auto redirectArticle = std::make_shared<RedirectArticle>(
-      matches[1].str()[0],
-      matches[2].str(),
-      matches[3].str(),
-      matches[4].str());
+      matches[1].str()[0],  // ns
+      matches[2].str(),     // URL
+      matches[3].str(),     // title
+      matches[4].str());    // redirect URL
     addArticle(redirectArticle);
     ++line_number;
   }
@@ -140,9 +140,9 @@ void ZimCreatorFS::visitDirectory(const std::string& path)
   closedir(directory);
 }
 
-void ZimCreatorFS::addMetadata(const std::string& metadata, const std::string& content)
+void ZimCreatorFS::addMetadata(const std::string& title, const std::string& content)
 {
-  auto article = std::make_shared<SimpleMetadataArticle>(metadata, content);
+  auto article = std::make_shared<SimpleMetadataArticle>(title, content);
   addArticle(article);
 }
 

--- a/src/zimwriterfs/zimcreatorfs.h
+++ b/src/zimwriterfs/zimcreatorfs.h
@@ -38,11 +38,13 @@ class IHandler
 class ZimCreatorFS : public zim::writer::Creator
 {
  public:
-  ZimCreatorFS(std::string mainPage, bool verbose, bool uniqueNamespace)
+  ZimCreatorFS(std::string _directoryPath, std::string mainPage, bool verbose, bool uniqueNamespace)
     : zim::writer::Creator(verbose),
+      directoryPath(_directoryPath),
       mainPage(mainPage),
       uniqueNamespace(uniqueNamespace){}
   virtual ~ZimCreatorFS() = default;
+
   virtual zim::writer::Url getMainUrl() const;
   virtual void add_customHandler(IHandler* handler);
   virtual void add_redirectArticles_from_file(const std::string& path);
@@ -53,8 +55,13 @@ class ZimCreatorFS : public zim::writer::Creator
   virtual void addArticle(std::shared_ptr<zim::writer::Article> article);
   virtual void finishZimCreation();
 
+  std::string computeNewUrl(const std::string& aid, const std::string& baseUrl, const std::string& targetUrl) const;
+  const std::string & basedir() const { return directoryPath; }
+  bool uniqNamespace() const { return uniqueNamespace; }
+
  private:
   std::vector<IHandler*> articleHandlers;
+  std::string directoryPath;  ///< html dir without trailing slash
   std::string mainPage;
   bool uniqueNamespace;
 };

--- a/src/zimwriterfs/zimwriterfs.cpp
+++ b/src/zimwriterfs/zimwriterfs.cpp
@@ -52,7 +52,6 @@ std::string source;
 std::string description;
 std::string welcome;
 std::string favicon;
-std::string directoryPath;  ///< html directory without trailing slash
 std::string redirectsPath;
 std::string zimPath;
 
@@ -168,6 +167,7 @@ void usage()
 int main(int argc, char** argv)
 {
   int minChunkSize = 2048;
+  std::string directoryPath;
 
   /* Argument parsing */
   static struct option long_options[]
@@ -329,7 +329,7 @@ int main(int argc, char** argv)
     tags += ";_ftindex"; // For backward compatibility
   }
 
-  ZimCreatorFS zimCreator(welcome, isVerbose(), uniqueNamespace);
+  ZimCreatorFS zimCreator(directoryPath, welcome, isVerbose(), uniqueNamespace);
 
   zimCreator.setMinChunkSize(minChunkSize);
   zimCreator.setIndexing(!withoutFTIndex, language);

--- a/src/zimwriterfs/zimwriterfs.cpp
+++ b/src/zimwriterfs/zimwriterfs.cpp
@@ -52,7 +52,7 @@ std::string source;
 std::string description;
 std::string welcome;
 std::string favicon;
-std::string directoryPath;
+std::string directoryPath;  ///< html directory without trailing slash
 std::string redirectsPath;
 std::string zimPath;
 
@@ -297,6 +297,8 @@ int main(int argc, char** argv)
   }
 
   /* Check arguments */
+
+  // delete / from the end of filename
   if (directoryPath[directoryPath.length() - 1] == '/') {
     directoryPath = directoryPath.substr(0, directoryPath.length() - 1);
   }

--- a/test/data/minimal-content/hello.html
+++ b/test/data/minimal-content/hello.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+ <head>
+  <meta charset="utf-8" />
+  <title>HTML title tag content</title>
+ </head>
+ <body>
+  <p>hello, html</p>
+ </body>
+</html>

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,8 +1,9 @@
 gtest_dep = dependency('gtest', main:true, fallback:['gtest', 'gtest_main_dep'], required:false)
 
 tests = [
+    'tools-test',
     'zimwriterfs-article',
-    'tools-test'
+    'zimwriterfs-zimcreatorfs'
 ]
 
 zimwriter_srcs = [  '../src/zimwriterfs/article.cpp',

--- a/test/tools-test.cpp
+++ b/test/tools-test.cpp
@@ -4,7 +4,6 @@
 #include <magic.h>
 #include <unordered_map>
 
-std::string directoryPath;
 magic_t magic;
 bool inflateHtmlFlag = false;
 bool isVerbose() { return false; }

--- a/test/zimwriterfs-article.cpp
+++ b/test/zimwriterfs-article.cpp
@@ -19,11 +19,11 @@
 #include <magic.h>
 
 #include "../src/zimwriterfs/article.h"
+#include "../src/zimwriterfs/zimcreatorfs.h"
 #include "gtest/gtest.h"
 #include "../src/tools.h"
 
 // stub from zimwriterfs.cpp
-std::string directoryPath;  // html dir without trailing slash
 bool isVerbose() { return false; }
 bool inflateHtmlFlag = false;
 magic_t magic;
@@ -91,12 +91,14 @@ TEST(ArticleTest, MetadataDate)
 
 TEST(ArticleTest, FileArticlePng)
 {
-  directoryPath = "data/minimal-content";
+  std::string directoryPath = "data/minimal-content";
+  ZimCreatorFS creator(directoryPath, "mainPage", false, false);
+
   std::string fn = "favicon.png";
   unsigned int size = getFileSize(directoryPath + "/" + fn);
   std::string data = getFileContent(directoryPath + "/" + fn);
 
-  FileArticle article(directoryPath + "/" + fn, false);
+  FileArticle article(&creator, directoryPath + "/" + fn, false);
 
   // test zim::writer::Article interface
   EXPECT_EQ(article.getUrl(), zim::writer::Url('I', fn));
@@ -121,12 +123,14 @@ TEST(ArticleTest, FileArticlePng)
 
 TEST(ArticleTest, FileArticleHTML)
 {
-  directoryPath = "data/minimal-content";
+  std::string directoryPath = "data/minimal-content";
+  ZimCreatorFS creator(directoryPath, "mainPage", false, false);
+
   std::string fn = "hello.html";
   unsigned int size = getFileSize(directoryPath + "/" + fn);
   std::string data = getFileContent(directoryPath + "/" + fn);
 
-  FileArticle article(directoryPath + "/" + fn, false);
+  FileArticle article(&creator, directoryPath + "/" + fn, false);
 
   // see FileArticle::getFilename() and the constructor
   // because HTML content are read right away, getFilename() always returns empty string
@@ -149,7 +153,10 @@ TEST(ArticleTest, FileArticleHTML)
 
 TEST(ArticleTest, RedirectArticle)
 {
-  RedirectArticle article('A', "index.html", "Start page", zim::writer::Url("A/home.html"));
+  std::string directoryPath = "data/minimal-content";
+  ZimCreatorFS creator(directoryPath, "mainPage", false, false);
+
+  RedirectArticle article(&creator, 'A', "index.html", "Start page", zim::writer::Url("A/home.html"));
 
   // test zim::writer::Article interface
   EXPECT_EQ(article.getUrl(), zim::writer::Url('A', "index.html"));

--- a/test/zimwriterfs-article.cpp
+++ b/test/zimwriterfs-article.cpp
@@ -15,38 +15,156 @@
  *
  */
 
-#include "../src/zimwriterfs/article.h"
-
-#include "gtest/gtest.h"
+#include <iostream>
 #include <magic.h>
 
+#include "../src/zimwriterfs/article.h"
+#include "gtest/gtest.h"
+#include "../src/tools.h"
+
 // stub from zimwriterfs.cpp
-std::string directoryPath = ".";
-bool isVerbose() { return true; }
+std::string directoryPath;  // html dir without trailing slash
+bool isVerbose() { return false; }
 bool inflateHtmlFlag = false;
-bool uniqueNamespace = false;
 magic_t magic;
 
-namespace
-{
-class ArticleTest : public ::testing::Test
-{
-public:
-  ArticleTest() {
-    magic = magic_open(MAGIC_MIME);
-    magic_load(magic, NULL);
-  }
 
-  ~ArticleTest() {
-      magic_close(magic);
-  }
-};
+TEST(ArticleTest, SimpleMetadata)
+{
+  std::string t = "Example content";
+  SimpleMetadataArticle article("Title", t);
 
-TEST(ArticleTest, Metadata)
+  // test zim::writer::Article interface
+  EXPECT_EQ(article.getUrl(), zim::writer::Url('M', "Title"));
+  EXPECT_EQ(article.getTitle(), "");
+  ASSERT_FALSE(article.isRedirect());
+  ASSERT_FALSE(article.isLinktarget());
+  ASSERT_FALSE(article.isDeleted());
+  EXPECT_EQ(article.getMimeType(), "text/plain");
+  ASSERT_TRUE(article.shouldCompress());
+  ASSERT_FALSE(article.shouldIndex());
+  EXPECT_EQ(article.getRedirectUrl(), zim::writer::Url());
+  EXPECT_EQ(article.getSize(), t.size());
+  ASSERT_EQ(article.getData(), zim::Blob(t.data(), t.size()));
+  EXPECT_EQ(article.getFilename(), "");
+}
+
+
+TEST(ArticleTest, MetadataFaviconArticle)
+{
+  std::string fn = "favicon.png";
+
+  MetadataFaviconArticle article("I/" + fn);
+
+  // test zim::writer::Article interface
+  EXPECT_EQ(article.getUrl(), zim::writer::Url('-', "favicon"));
+  EXPECT_EQ(article.getTitle(), "");
+  ASSERT_TRUE(article.isRedirect());
+  EXPECT_FALSE(article.isLinktarget());
+  EXPECT_FALSE(article.isDeleted());
+  ASSERT_EQ(article.getMimeType(), "image/png");
+  EXPECT_FALSE(article.shouldCompress());
+  EXPECT_FALSE(article.shouldIndex());
+  EXPECT_EQ(article.getRedirectUrl(), zim::writer::Url('I', fn));
+  ASSERT_EQ(article.getSize(), 0);
+  ASSERT_EQ(article.getData(), zim::Blob());
+  EXPECT_EQ(article.getFilename(), "");
+}
+
+TEST(ArticleTest, MetadataDate)
 {
   MetadataDateArticle article;
 
+  // test zim::writer::Article interface
+  EXPECT_EQ(article.getUrl(), zim::writer::Url('M', "Date"));
+  EXPECT_EQ(article.getTitle(), "");
+  ASSERT_FALSE(article.isRedirect());
+  ASSERT_FALSE(article.isLinktarget());
   ASSERT_FALSE(article.isDeleted());
+  EXPECT_EQ(article.getMimeType(), "text/plain");
+  ASSERT_TRUE(article.shouldCompress());
+  ASSERT_FALSE(article.shouldIndex());
+  EXPECT_EQ(article.getRedirectUrl(), zim::writer::Url());
+  EXPECT_TRUE(article.getSize() > 8 && article.getSize() < 15); // date string is about 10 chars
+  EXPECT_EQ(article.getFilename(), "");
 }
 
-}  // namespace
+TEST(ArticleTest, FileArticlePng)
+{
+  directoryPath = "data/minimal-content";
+  std::string fn = "favicon.png";
+  unsigned int size = getFileSize(directoryPath + "/" + fn);
+  std::string data = getFileContent(directoryPath + "/" + fn);
+
+  FileArticle article(directoryPath + "/" + fn, false);
+
+  // test zim::writer::Article interface
+  EXPECT_EQ(article.getUrl(), zim::writer::Url('I', fn));
+  EXPECT_EQ(article.getTitle(), "");
+  ASSERT_FALSE(article.isRedirect());
+  EXPECT_FALSE(article.isLinktarget());
+  EXPECT_FALSE(article.isDeleted());
+  ASSERT_EQ(article.getMimeType(), "image/png");
+  EXPECT_FALSE(article.shouldCompress());
+  EXPECT_FALSE(article.shouldIndex());
+  EXPECT_EQ(article.getRedirectUrl(), zim::writer::Url());
+  ASSERT_EQ(article.getSize(), size);
+
+  // see FileArticle::getFilename()
+  // after file content is read, getFilename() no more returns the filename
+  EXPECT_EQ(article.getFilename(), directoryPath + "/" + fn);
+  ASSERT_EQ(article.getData(), zim::Blob(data.data(), data.size()));
+  EXPECT_EQ(article.getFilename(), "");
+  // file size still should be returned:
+  EXPECT_EQ(article.getSize(), size);
+}
+
+TEST(ArticleTest, FileArticleHTML)
+{
+  directoryPath = "data/minimal-content";
+  std::string fn = "hello.html";
+  unsigned int size = getFileSize(directoryPath + "/" + fn);
+  std::string data = getFileContent(directoryPath + "/" + fn);
+
+  FileArticle article(directoryPath + "/" + fn, false);
+
+  // see FileArticle::getFilename() and the constructor
+  // because HTML content are read right away, getFilename() always returns empty string
+  EXPECT_EQ(article.getFilename(), "");
+
+  // test zim::writer::Article interface
+  EXPECT_EQ(article.getUrl(), zim::writer::Url('A', fn));
+  EXPECT_EQ(article.getTitle(), "HTML title tag content");
+  ASSERT_FALSE(article.isRedirect());
+  EXPECT_FALSE(article.isLinktarget());
+  EXPECT_FALSE(article.isDeleted());
+  ASSERT_EQ(article.getMimeType(), "text/html");
+  EXPECT_TRUE(article.shouldCompress());
+  EXPECT_TRUE(article.shouldIndex());
+  EXPECT_EQ(article.getRedirectUrl(), zim::writer::Url());
+  ASSERT_EQ(article.getSize(), size);
+  ASSERT_EQ(article.getData(), zim::Blob(data.data(), data.size()));
+  EXPECT_EQ(article.getFilename(), "");
+}
+
+TEST(ArticleTest, RedirectArticle)
+{
+  RedirectArticle article('A', "index.html", "Start page", zim::writer::Url("A/home.html"));
+
+  // test zim::writer::Article interface
+  EXPECT_EQ(article.getUrl(), zim::writer::Url('A', "index.html"));
+  EXPECT_EQ(article.getTitle(), "Start page");
+  ASSERT_TRUE(article.isRedirect());
+  EXPECT_FALSE(article.isLinktarget());
+  EXPECT_FALSE(article.isDeleted());
+  ASSERT_EQ(article.getMimeType(), "text/html");
+
+  // FIXME: maybe this is shouldn't be that way:
+  EXPECT_TRUE(article.shouldCompress());
+  EXPECT_TRUE(article.shouldIndex());
+
+  EXPECT_EQ(article.getRedirectUrl(), zim::writer::Url('A', "home.html"));
+  ASSERT_EQ(article.getSize(), 0);
+  ASSERT_EQ(article.getData(), zim::Blob());
+  EXPECT_EQ(article.getFilename(), "");
+}

--- a/test/zimwriterfs-zimcreatorfs.cpp
+++ b/test/zimwriterfs-zimcreatorfs.cpp
@@ -1,0 +1,96 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#include <unistd.h>
+#include <iostream>
+#include <magic.h>
+
+#include <zim/file.h>
+#include <zim/fileiterator.h>
+
+#include "gtest/gtest.h"
+
+#include "../src/zimwriterfs/zimcreatorfs.h"
+#include "../src/zimwriterfs/article.h"
+#include "../src/tools.h"
+
+
+// stub from zimwriterfs.cpp
+std::string directoryPath;
+bool inflateHtmlFlag = false;
+bool isVerbose() { return false; }
+magic_t magic;
+
+class LibMagicInit
+{
+public:
+  LibMagicInit()
+  {
+    if (! done) {
+      magic = magic_open(MAGIC_MIME);
+      magic_load(magic, NULL);
+      done = true;
+    }
+  }
+private:
+  static bool done;
+};
+
+bool LibMagicInit::done = false;
+
+
+class TempFile
+{
+public:
+  TempFile(const char *name) { _name = "/tmp/"; _name += name; }
+  ~TempFile() { unlink(_name.c_str()); }
+  const char *path() { return _name.c_str(); }
+private:
+  std::string _name;
+};
+
+
+TEST(ZimCreatorFSTest, MinimalZim)
+{
+  LibMagicInit libmagic;
+
+  TempFile out("minimal.zim");
+  ZimCreatorFS zimCreator("index.html", false, false);
+
+  zimCreator.startZimCreation(out.path());
+
+  // it's necessary to setup global variable 'directoryPath'
+  // for class Article, determining 'url' as filename without 'directoryPath'
+  directoryPath = "data/minimal-content";
+
+  zimCreator.visitDirectory(directoryPath);
+
+  std::shared_ptr<zim::writer::Article> redirect_article(new RedirectArticle('A', "index.html", "Start page", zim::writer::Url("A/hello.html")));
+  zimCreator.addArticle(redirect_article);
+
+  zimCreator.finishZimCreation();
+
+  // verify the created .zim file with 'zimdump'
+  zim::File zimfile(out.path());
+  EXPECT_EQ(zimfile.getCountArticles(), 4);
+
+  zim::Article a1 = zimfile.getArticle('A', "index.html");
+  EXPECT_TRUE(a1.isRedirect());
+
+  zim::Article a2 = a1.getRedirectArticle();
+  EXPECT_EQ(a2.getTitle(), "HTML title tag content");
+}

--- a/test/zimwriterfs-zimcreatorfs.cpp
+++ b/test/zimwriterfs-zimcreatorfs.cpp
@@ -30,7 +30,6 @@
 
 
 // stub from zimwriterfs.cpp
-std::string directoryPath;
 bool inflateHtmlFlag = false;
 bool isVerbose() { return false; }
 magic_t magic;
@@ -68,18 +67,15 @@ TEST(ZimCreatorFSTest, MinimalZim)
 {
   LibMagicInit libmagic;
 
+  std::string directoryPath = "data/minimal-content";
+  ZimCreatorFS zimCreator(directoryPath, "index.html", false, false);
+
   TempFile out("minimal.zim");
-  ZimCreatorFS zimCreator("index.html", false, false);
 
   zimCreator.startZimCreation(out.path());
-
-  // it's necessary to setup global variable 'directoryPath'
-  // for class Article, determining 'url' as filename without 'directoryPath'
-  directoryPath = "data/minimal-content";
-
   zimCreator.visitDirectory(directoryPath);
 
-  std::shared_ptr<zim::writer::Article> redirect_article(new RedirectArticle('A', "index.html", "Start page", zim::writer::Url("A/hello.html")));
+  std::shared_ptr<zim::writer::Article> redirect_article(new RedirectArticle(&zimCreator, 'A', "index.html", "Start page", zim::writer::Url("A/hello.html")));
   zimCreator.addArticle(redirect_article);
 
   zimCreator.finishZimCreation();


### PR DESCRIPTION
Related to #98, part 3

Work in progress: waiting while part 2 of this change is merged:

* part 1: #130
* part 2: #142
* part 3: this PR

This PR adds unit tests for zimwriterfs classes: Article and its subclasses, and ZimCreatorFS.
