### PR TITLE
New zimwriterfs & zimrecreate --zstd option

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+zim-tools 2.1.0
+===============
+
+* zimwriterfs & zimrecreate: write ZIM files using Zstandard compression
+
 zim-tools 2.0.0
 ===============
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,15 @@ Meson. If you want statically linked libraries, you can add
 
 Depending of you system, `ninja` may be called `ninja-build`.
 
+Testing
+-------
+
+To run the automated tests:
+```bash
+cd build
+meson test
+```
+
 Installation
 ------------
 

--- a/src/zimrecreate.cpp
+++ b/src/zimrecreate.cpp
@@ -119,8 +119,8 @@ class ZimRecreator : public zim::writer::Creator
     zim::File origin;
 
 public:
-    explicit ZimRecreator(std::string originFilename="") :
-      zim::writer::Creator(true)
+  explicit ZimRecreator(std::string originFilename="", bool zstd = false) :
+    zim::writer::Creator(true, zstd ? zim::zimcompZstd : zim::zimcompLzma)
     {
         origin = zim::File(originFilename);
         // [TODO] Use the correct language
@@ -179,14 +179,17 @@ public:
 
 void usage()
 {
-    std::cout<<"\nzimrecreate recreates a ZIM file from a existing ZIM.\n"
-    "\nUsage: zimrecreate [origin_file] [output file]"
-    "\nOption: -v, --version    print software version\n";
+    std::cout << "\nzimrecreate recreates a ZIM file from a existing ZIM.\n"
+    "\nUsage: zimrecreate [Options] ORIGIN_FILE OUTPUT_FILE"
+    "\nOptions:\n"
+    "\t-v, --version    print software version\n"
+    "\t-z, --zstd       use Zstandard as ZIM compression (lzma otherwise)\n";
     return;
 }
 
 int main(int argc, char* argv[])
 {
+    bool zstdFlag = false;
 
     //Parsing arguments
     //There will be only two arguments, so no detailed parsing is required.
@@ -207,6 +210,12 @@ int main(int argc, char* argv[])
             version();
             return 0;
         }
+
+        if(std::string(argv[i])=="--zstd" ||
+           std::string(argv[i])=="-z")
+        {
+            zstdFlag = true;
+        }
     }
     if(argc<3)
     {
@@ -218,7 +227,7 @@ int main(int argc, char* argv[])
     std::string outputFilename =argv[2];
     try
     {
-        ZimRecreator c(originFilename);
+        ZimRecreator c(originFilename, zstdFlag);
         //Create the actual file.
         c.create(outputFilename);
     }

--- a/src/zimwriterfs/zimcreatorfs.h
+++ b/src/zimwriterfs/zimcreatorfs.h
@@ -38,8 +38,9 @@ class IHandler
 class ZimCreatorFS : public zim::writer::Creator
 {
  public:
-  ZimCreatorFS(std::string _directoryPath, std::string mainPage, bool verbose, bool uniqueNamespace)
-    : zim::writer::Creator(verbose),
+  ZimCreatorFS(std::string _directoryPath, std::string mainPage, bool verbose,
+               bool uniqueNamespace, bool zstd = false)
+    : zim::writer::Creator(verbose, zstd ? zim::zimcompZstd : zim::zimcompLzma),
       directoryPath(_directoryPath),
       mainPage(mainPage),
       uniqueNamespace(uniqueNamespace){}

--- a/src/zimwriterfs/zimwriterfs.cpp
+++ b/src/zimwriterfs/zimwriterfs.cpp
@@ -60,6 +60,7 @@ pthread_mutex_t verboseMutex;
 bool inflateHtmlFlag = false;
 bool uniqueNamespace = false;
 bool withoutFTIndex = false;
+bool zstdFlag = false;
 
 magic_t magic;
 
@@ -147,6 +148,8 @@ void usage()
             << std::endl;
   std::cout << "\t-s, --scraper\t\tname & version of tool used to produce HTML content"
             << std::endl;
+  std::cout << "\t-z, --zstd\t\tuse Zstandard as ZIM compression (lzma otherwise)"
+            << std::endl;
   std::cout << std::endl;
 
   std::cout << "Example:" << std::endl;
@@ -190,6 +193,7 @@ int main(int argc, char** argv)
          {"description", required_argument, 0, 'd'},
          {"creator", required_argument, 0, 'c'},
          {"publisher", required_argument, 0, 'p'},
+         {"zstd", no_argument, 0, 'z'},
          {"withoutFTIndex", no_argument, 0, 'j'},
 
          // Only for backward compatibility
@@ -201,7 +205,7 @@ int main(int argc, char** argv)
 
   do {
     c = getopt_long(
-        argc, argv, "hVvijxuw:m:f:t:d:c:l:p:r:e:n:", long_options, &option_index);
+        argc, argv, "hVvijxuzw:m:f:t:d:c:l:p:r:e:n:", long_options, &option_index);
 
     if (c != -1) {
       switch (c) {
@@ -270,6 +274,9 @@ int main(int argc, char** argv)
         case 'w':
           welcome = optarg;
           break;
+        case 'z':
+          zstdFlag = true;
+          break;
       }
     }
   } while (c != -1);
@@ -329,7 +336,7 @@ int main(int argc, char** argv)
     tags += ";_ftindex"; // For backward compatibility
   }
 
-  ZimCreatorFS zimCreator(directoryPath, welcome, isVerbose(), uniqueNamespace);
+  ZimCreatorFS zimCreator(directoryPath, welcome, isVerbose(), uniqueNamespace, zstdFlag);
 
   zimCreator.setMinChunkSize(minChunkSize);
   zimCreator.setIndexing(!withoutFTIndex, language);


### PR DESCRIPTION
I have just added `-zstd` to fix #82 and #115 and not a `--compression` like requested. The goal of the `libzim` not being to support multiple compressions algorithm at the same time (because this tends to complexify the portability, the maintainability). To me this option is only transitory and utlimatively will be removed (and everything will be using zstd compression).