### PR TITLE
Reduced the number of calls to generic_getLinks.

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -319,16 +319,19 @@ void remove_all(const std::string& path)
   }
 }
 
-std::vector<std::string> generic_getLinks(const std::string& page, bool withHref)
+std::vector<html_link> generic_getLinks(const std::string& page)
 {
     const char* p = page.c_str();
     const char* linkStart;
-    std::vector<std::string> links;
+    std::vector<html_link> links;
+    std::string attr;
 
     while (*p) {
-        if (withHref && strncmp(p, " href", 5) == 0) {
+        if (strncmp(p, " href", 5) == 0) {
+            attr = "href";
             p += 5;
         } else if (strncmp(p, " src", 4) == 0) {
+            attr = "src";
             p += 4;
         } else {
             p += 1;
@@ -349,7 +352,7 @@ std::vector<std::string> generic_getLinks(const std::string& page, bool withHref
         // [TODO] Handle escape char
         while(*p != delimiter)
             p++;
-        links.push_back(std::string(linkStart, p));
+        links.push_back({attr,std::string(linkStart, p)});
         p += 1;
     }
     return links;

--- a/src/tools.h
+++ b/src/tools.h
@@ -25,6 +25,12 @@
 #include <string>
 #include <vector>
 
+typedef struct html_link
+{
+    std::string attribute;
+    std::string link;
+} html_link;
+
 std::string getMimeTypeForFile(const std::string& basedir, const std::string& filename);
 std::string getNamespaceForMimeType(const std::string& mimeType, bool uniqueNamespace);
 std::string getFileContent(const std::string& path);
@@ -51,7 +57,7 @@ std::string computeRelativePath(const std::string path,
 void remove_all(const std::string& path);
 
 //Returns a vector of the links in a particular page. includes links under 'href' and 'src'
-std::vector<std::string> generic_getLinks(const std::string& page, bool withHref = true);
+std::vector<html_link> generic_getLinks(const std::string& page);
 
 // checks if a relative path is out of bounds (relative to base)
 bool isOutofBounds(const std::string& input, std::string base);

--- a/test/tools-test.cpp
+++ b/test/tools-test.cpp
@@ -207,19 +207,20 @@ TEST(tools, getLinks)
     std::string page1 = "<link href=\"https://fonts.goos.com/css?family=OpenSans\" rel=\"stylesheet\">";
     auto v1 = generic_getLinks(page1);
 
-    ASSERT_FALSE(v1.empty());
     ASSERT_TRUE(v1.size() == 1);
-    ASSERT_EQ(v1[0], "https://fonts.goos.com/css?family=OpenSans");
+    ASSERT_EQ(v1[0].attribute, "href");
+    ASSERT_EQ(v1[0].link, "https://fonts.goos.com/css?family=OpenSans");
 
     std::string page2 = "<link href=\"https://fonts.goos.com/css?family=OpenSans\" rel=\"stylesheet\">";
-    auto v2 = generic_getLinks(page2, false);
+    auto v2 = generic_getLinks(page2);
 
-    ASSERT_TRUE(v2.empty());
+    ASSERT_TRUE(v2.size() == 1);
+    ASSERT_EQ(v1[0].attribute, "href");
 
     std::string page3 = "<link src=\"https://fonts.goos.com/css?family=OpenSans\" rel=\"stylesheet\">";
     auto v3 = generic_getLinks(page3);
 
-    ASSERT_FALSE(v3.empty());
     ASSERT_TRUE(v3.size() == 1);
-    ASSERT_EQ(v3[0], "https://fonts.goos.com/css?family=OpenSans");
+    ASSERT_EQ(v3[0].attribute, "src");
+    ASSERT_EQ(v3[0].link, "https://fonts.goos.com/css?family=OpenSans");
 }


### PR DESCRIPTION
Refactored generic_getLinks to parse all src and href type links.
Removed getDependencies()
Make zimcheck call generic_getLinks only once