### PR TITLE
Fixes #157 Do not allow to create .zim inside of source HTML dir

### DIFF
--- a/src/zimwriterfs/zimcreatorfs.h
+++ b/src/zimwriterfs/zimcreatorfs.h
@@ -56,6 +56,7 @@ class ZimCreatorFS : public zim::writer::Creator
   std::string computeNewUrl(const std::string& aid, const std::string& baseUrl, const std::string& targetUrl) const;
   const std::string & basedir() const { return directoryPath; }
   bool uniqNamespace() const { return uniqueNamespace; }
+  const std::string & canonicalBaseDir() const { return canonical_basedir; }
 
  private:
   std::vector<IHandler*> articleHandlers;


### PR DESCRIPTION
Fixes #157: Prevent creation of .zim under HTML source directory.