### PR TITLE
Optimization of isExternalUrl() and friends

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -249,7 +249,7 @@ std::vector<html_link> generic_getLinks(const std::string& page)
         while(*p != delimiter)
             p++;
         const std::string link(linkStart, p);
-        links.push_back({attr, link, uriKind(link)});
+        links.push_back(html_link(attr, link));
         p += 1;
     }
     return links;
@@ -391,7 +391,7 @@ void asciitolower(std::string& s)
 
 } // unnamed namespace
 
-UriKind uriKind(const std::string& input_string)
+UriKind html_link::detectUriKind(const std::string& input_string)
 {
     const auto k = input_string.find_first_of(":/?#");
     if ( k == std::string::npos || input_string[k] != ':' )

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -363,21 +363,6 @@ std::string normalize_link(const std::string& input, const std::string& baseUrl)
 namespace
 {
 
-enum class UriKind : int
-{
-    // Special URIs without authority that are valid in HTML
-    JAVASCRIPT,     // javascript:...
-    MAILTO,         // mailto:user@example.com
-    TEL,            // tel:+0123456789
-    GEO,            // geo:12.34,56.78
-    DATA,           // data:image/png;base64,...
-
-    GENERIC_URI,    // Generic URI with scheme and authority: <scheme>://.....
-
-    INVALID         // not a valid URI (though it can be a valid relative
-                    // or absolute URL)
-};
-
 const char* const uriSchemes[] = {
     "javascript",
     "mailto",
@@ -403,8 +388,8 @@ void asciitolower(std::string& s)
     });
 }
 
-// Detects the URI type of the input string. Special URI kinds are considered
-// up to and including the value of the second parameter max_special_kind
+} // unnamed namespace
+
 UriKind uriKind(const std::string& input_string, UriKind max_special_kind)
 {
     const auto k = input_string.find_first_of(":/?#");
@@ -421,17 +406,3 @@ UriKind uriKind(const std::string& input_string, UriKind max_special_kind)
     return specialUriSchemeKind(scheme, int(max_special_kind));
 }
 
-} // unnamed namespace
-
-bool isExternalUrl(const std::string& input_string)
-{
-    // A string starting with "<scheme>://" or "geo:" or "tel:"
-    // or "javascript:" or "mailto:"
-    return uriKind(input_string, UriKind::GEO) != UriKind::INVALID;
-}
-
-// Checks if a URL is an internal URL or not. Uses RegExp.
-bool isInternalUrl(const std::string& input_string)
-{
-    return uriKind(input_string, UriKind::DATA) == UriKind::INVALID;
-}

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -379,7 +379,7 @@ UriKind specialUriSchemeKind(const std::string& s)
             return UriKind(i);
     }
 
-    return UriKind::INVALID;
+    return UriKind::OTHER;
 }
 
 void asciitolower(std::string& s)
@@ -395,7 +395,7 @@ UriKind html_link::detectUriKind(const std::string& input_string)
 {
     const auto k = input_string.find_first_of(":/?#");
     if ( k == std::string::npos || input_string[k] != ':' )
-        return UriKind::INVALID;
+        return UriKind::OTHER;
 
     if ( k + 2 < input_string.size()
          && input_string[k+1] == '/'

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -249,7 +249,7 @@ std::vector<html_link> generic_getLinks(const std::string& page)
         while(*p != delimiter)
             p++;
         const std::string link(linkStart, p);
-        links.push_back({attr, link, uriKind(link, UriKind::DATA)});
+        links.push_back({attr, link, uriKind(link)});
         p += 1;
     }
     return links;
@@ -372,9 +372,9 @@ const char* const uriSchemes[] = {
     "data"
 };
 
-UriKind specialUriSchemeKind(const std::string& s, int n)
+UriKind specialUriSchemeKind(const std::string& s)
 {
-    for ( int i = 0; i <= n ; ++i ) {
+    for ( int i = 0; i <= int(UriKind::DATA) ; ++i ) {
         if ( uriSchemes[i] == s )
             return UriKind(i);
     }
@@ -391,7 +391,7 @@ void asciitolower(std::string& s)
 
 } // unnamed namespace
 
-UriKind uriKind(const std::string& input_string, UriKind max_special_kind)
+UriKind uriKind(const std::string& input_string)
 {
     const auto k = input_string.find_first_of(":/?#");
     if ( k == std::string::npos || input_string[k] != ':' )
@@ -404,6 +404,6 @@ UriKind uriKind(const std::string& input_string, UriKind max_special_kind)
 
     std::string scheme = input_string.substr(0, k);
     asciitolower(scheme);
-    return specialUriSchemeKind(scheme, int(max_special_kind));
+    return specialUriSchemeKind(scheme);
 }
 

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -384,21 +384,21 @@ bool isExternalUrl(const std::string& input_string)
     // A string starting with "<scheme>://" or "geo:" or "tel:"
     // or "javascript:" or "mailto:"
 
-    const auto colon_pos = input_string.find(':');
-    if ( colon_pos == std::string::npos )
+    const auto k = input_string.find_first_of(":/?#");
+    if ( k == std::string::npos || input_string[k] != ':' )
         return false;
 
-    std::string scheme = input_string.substr(0, colon_pos);
-    asciitolower(scheme);
-
-    if ( scheme == "javascript" ||
-         scheme == "mailto" ||
-         scheme == "tel" ||
-         scheme == "geo" )
+    if ( k + 2 < input_string.size()
+         && input_string[k+1] == '/'
+         && input_string[k+2] == '/' )
         return true;
 
-    return input_string.substr(colon_pos+1, 2) == "//"
-        && scheme.find_first_of("/?#") == std::string::npos;
+    std::string scheme = input_string.substr(0, k);
+    asciitolower(scheme);
+    return scheme == "javascript" ||
+           scheme == "mailto" ||
+           scheme == "tel" ||
+           scheme == "geo";
 }
 
 // Checks if a URL is an internal URL or not. Uses RegExp.

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -248,7 +248,8 @@ std::vector<html_link> generic_getLinks(const std::string& page)
         // [TODO] Handle escape char
         while(*p != delimiter)
             p++;
-        links.push_back({attr,std::string(linkStart, p)});
+        const std::string link(linkStart, p);
+        links.push_back({attr, link, uriKind(link, UriKind::DATA)});
         p += 1;
     }
     return links;

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -32,6 +32,7 @@
 #include <memory>
 #include <unistd.h>
 #include <algorithm>
+#include <regex>
 
 #ifdef _WIN32
 #define SEPARATOR "\\"
@@ -357,4 +358,26 @@ std::string normalize_link(const std::string& input, const std::string& baseUrl)
         output += *(p++);
     }
     return output;
+}
+
+bool isDataUrl(const std::string& input_string)
+{
+    static std::regex data_url_regex =
+      std::regex("data:.+", std::regex_constants::icase);
+    return std::regex_match(input_string, data_url_regex);
+}
+
+bool isExternalUrl(const std::string& input_string)
+{
+    // A string starting with "<scheme>://" or "geo:" or "tel:" or "javascript:" or "mailto:"
+    static std::regex external_url_regex =
+      std::regex("([^:/?#]+:\\/\\/|geo:|tel:|mailto:|javascript:).*",
+                 std::regex_constants::icase);
+    return std::regex_match(input_string, external_url_regex);
+}
+
+// Checks if a URL is an internal URL or not. Uses RegExp.
+bool isInternalUrl(const std::string& input_string)
+{
+    return !isExternalUrl(input_string) && !isDataUrl(input_string);
 }

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -364,22 +364,18 @@ std::string normalize_link(const std::string& input, const std::string& baseUrl)
 namespace
 {
 
-const char* const uriSchemes[] = {
-    "javascript",
-    "mailto",
-    "tel",
-    "geo",
-    "data"
-};
-
 UriKind specialUriSchemeKind(const std::string& s)
 {
-    for ( int i = 0; i <= int(UriKind::DATA) ; ++i ) {
-        if ( uriSchemes[i] == s )
-            return UriKind(i);
-    }
+    static const std::map<std::string, UriKind> uriSchemes = {
+        { "javascript", UriKind::JAVASCRIPT },
+        { "mailto",     UriKind::MAILTO     },
+        { "tel",        UriKind::TEL        },
+        { "geo",        UriKind::GEO        },
+        { "data",       UriKind::DATA       }
+    };
 
-    return UriKind::OTHER;
+    const auto it = uriSchemes.find(s);
+    return it != uriSchemes.end() ? it->second : UriKind::OTHER;
 }
 
 void asciitolower(std::string& s)

--- a/src/tools.h
+++ b/src/tools.h
@@ -73,12 +73,23 @@ enum class UriKind : int
                     // or absolute URL)
 };
 
-typedef struct html_link
+class html_link
 {
+public:
     std::string attribute;
     std::string link;
     UriKind     uriKind;
-} html_link;
+
+    bool isExternalUrl() const
+    {
+        return uriKind != UriKind::INVALID && uriKind != UriKind::DATA;
+    }
+
+    bool isInternalUrl() const
+    {
+        return uriKind == UriKind::INVALID;
+    }
+};
 
 // Few helper class to help copy a item from a archive to another one.
 class ItemProvider : public zim::writer::ContentProvider
@@ -161,16 +172,6 @@ std::vector<html_link> generic_getLinks(const std::string& page);
 // Detects the URI type of the input string. Special URI kinds are considered
 // up to and including the value of the second parameter max_special_kind
 UriKind uriKind(const std::string& input_string);
-
-inline bool isExternalUrl(const html_link& l)
-{
-    return l.uriKind != UriKind::INVALID && l.uriKind != UriKind::DATA;
-}
-
-inline bool isInternalUrl(const html_link& l)
-{
-    return l.uriKind == UriKind::INVALID;
-}
 
 // checks if a relative path is out of bounds (relative to base)
 bool isOutofBounds(const std::string& input, std::string base);

--- a/src/tools.h
+++ b/src/tools.h
@@ -77,6 +77,7 @@ typedef struct html_link
 {
     std::string attribute;
     std::string link;
+    UriKind     uriKind;
 } html_link;
 
 // Few helper class to help copy a item from a archive to another one.
@@ -160,6 +161,16 @@ std::vector<html_link> generic_getLinks(const std::string& page);
 // Detects the URI type of the input string. Special URI kinds are considered
 // up to and including the value of the second parameter max_special_kind
 UriKind uriKind(const std::string& input_string, UriKind max_special_kind);
+
+inline bool isExternalUrl(const html_link& l)
+{
+    return l.uriKind != UriKind::INVALID && l.uriKind != UriKind::DATA;
+}
+
+inline bool isInternalUrl(const html_link& l)
+{
+    return l.uriKind == UriKind::INVALID;
+}
 
 // Checks if a URL is a string starting with "<scheme>://", "geo:", "tel:",
 // "javascript:" or "mailto:"

--- a/src/tools.h
+++ b/src/tools.h
@@ -58,6 +58,20 @@ private:
     std::stringstream stream_;
 };
 
+enum class UriKind : int
+{
+    // Special URIs without authority that are valid in HTML
+    JAVASCRIPT,     // javascript:...
+    MAILTO,         // mailto:user@example.com
+    TEL,            // tel:+0123456789
+    GEO,            // geo:12.34,56.78
+    DATA,           // data:image/png;base64,...
+
+    GENERIC_URI,    // Generic URI with scheme and authority: <scheme>://.....
+
+    INVALID         // not a valid URI (though it can be a valid relative
+                    // or absolute URL)
+};
 
 typedef struct html_link
 {
@@ -143,11 +157,22 @@ void stripTitleInvalidChars(std::string& str);
 //Returns a vector of the links in a particular page. includes links under 'href' and 'src'
 std::vector<html_link> generic_getLinks(const std::string& page);
 
-// Checks if a URL is an external url
-bool isExternalUrl(const std::string& input_string);
+// Detects the URI type of the input string. Special URI kinds are considered
+// up to and including the value of the second parameter max_special_kind
+UriKind uriKind(const std::string& input_string, UriKind max_special_kind);
 
-// Checks if a URL is an internal URL or not.
-bool isInternalUrl(const std::string& input_string);
+// Checks if a URL is a string starting with "<scheme>://", "geo:", "tel:",
+// "javascript:" or "mailto:"
+inline bool isExternalUrl(const std::string& input_string)
+{
+    return uriKind(input_string, UriKind::GEO) != UriKind::INVALID;
+}
+
+// Checks if a URL is an internal URL or not. Uses RegExp.
+inline bool isInternalUrl(const std::string& input_string)
+{
+    return uriKind(input_string, UriKind::DATA) == UriKind::INVALID;
+}
 
 // checks if a relative path is out of bounds (relative to base)
 bool isOutofBounds(const std::string& input, std::string base);

--- a/src/tools.h
+++ b/src/tools.h
@@ -143,9 +143,6 @@ void stripTitleInvalidChars(std::string& str);
 //Returns a vector of the links in a particular page. includes links under 'href' and 'src'
 std::vector<html_link> generic_getLinks(const std::string& page);
 
-// Checks if a URL is an internal data url of the form "data:..."
-bool isDataUrl(const std::string& input_string);
-
 // Checks if a URL is an external url
 bool isExternalUrl(const std::string& input_string);
 

--- a/src/tools.h
+++ b/src/tools.h
@@ -76,9 +76,15 @@ enum class UriKind : int
 class html_link
 {
 public:
-    std::string attribute;
-    std::string link;
-    UriKind     uriKind;
+    const std::string attribute;
+    const std::string link;
+    const UriKind     uriKind;
+
+    html_link(const std::string& _attr, const std::string& _link)
+        : attribute(_attr)
+        , link(_link)
+        , uriKind(detectUriKind(_link))
+    {}
 
     bool isExternalUrl() const
     {
@@ -89,6 +95,8 @@ public:
     {
         return uriKind == UriKind::INVALID;
     }
+
+    static UriKind detectUriKind(const std::string& input_string);
 };
 
 // Few helper class to help copy a item from a archive to another one.
@@ -168,10 +176,6 @@ void stripTitleInvalidChars(std::string& str);
 
 //Returns a vector of the links in a particular page. includes links under 'href' and 'src'
 std::vector<html_link> generic_getLinks(const std::string& page);
-
-// Detects the URI type of the input string. Special URI kinds are considered
-// up to and including the value of the second parameter max_special_kind
-UriKind uriKind(const std::string& input_string);
 
 // checks if a relative path is out of bounds (relative to base)
 bool isOutofBounds(const std::string& input, std::string base);

--- a/src/tools.h
+++ b/src/tools.h
@@ -69,7 +69,7 @@ enum class UriKind : int
 
     GENERIC_URI,    // Generic URI with scheme and authority: <scheme>://.....
 
-    INVALID         // not a valid URI (though it can be a valid relative
+    OTHER           // not a valid URI (though it can be a valid relative
                     // or absolute URL)
 };
 
@@ -88,12 +88,12 @@ public:
 
     bool isExternalUrl() const
     {
-        return uriKind != UriKind::INVALID && uriKind != UriKind::DATA;
+        return uriKind != UriKind::OTHER && uriKind != UriKind::DATA;
     }
 
     bool isInternalUrl() const
     {
-        return uriKind == UriKind::INVALID;
+        return uriKind == UriKind::OTHER;
     }
 
     static UriKind detectUriKind(const std::string& input_string);

--- a/src/tools.h
+++ b/src/tools.h
@@ -143,6 +143,15 @@ void stripTitleInvalidChars(std::string& str);
 //Returns a vector of the links in a particular page. includes links under 'href' and 'src'
 std::vector<html_link> generic_getLinks(const std::string& page);
 
+// Checks if a URL is an internal data url of the form "data:..."
+bool isDataUrl(const std::string& input_string);
+
+// Checks if a URL is an external url
+bool isExternalUrl(const std::string& input_string);
+
+// Checks if a URL is an internal URL or not.
+bool isInternalUrl(const std::string& input_string);
+
 // checks if a relative path is out of bounds (relative to base)
 bool isOutofBounds(const std::string& input, std::string base);
 

--- a/src/tools.h
+++ b/src/tools.h
@@ -160,7 +160,7 @@ std::vector<html_link> generic_getLinks(const std::string& page);
 
 // Detects the URI type of the input string. Special URI kinds are considered
 // up to and including the value of the second parameter max_special_kind
-UriKind uriKind(const std::string& input_string, UriKind max_special_kind);
+UriKind uriKind(const std::string& input_string);
 
 inline bool isExternalUrl(const html_link& l)
 {
@@ -170,19 +170,6 @@ inline bool isExternalUrl(const html_link& l)
 inline bool isInternalUrl(const html_link& l)
 {
     return l.uriKind == UriKind::INVALID;
-}
-
-// Checks if a URL is a string starting with "<scheme>://", "geo:", "tel:",
-// "javascript:" or "mailto:"
-inline bool isExternalUrl(const std::string& input_string)
-{
-    return uriKind(input_string, UriKind::GEO) != UriKind::INVALID;
-}
-
-// Checks if a URL is an internal URL or not. Uses RegExp.
-inline bool isInternalUrl(const std::string& input_string)
-{
-    return uriKind(input_string, UriKind::DATA) == UriKind::INVALID;
 }
 
 // checks if a relative path is out of bounds (relative to base)

--- a/src/zimcheck/checks.cpp
+++ b/src/zimcheck/checks.cpp
@@ -142,7 +142,7 @@ void test_articles(const zim::Archive& archive, ErrorLogger& reporter, ProgressB
             for (const auto &l : links)
             {
                 if (l.link.front() == '#' || l.link.front() == '?') continue;
-                if (isInternalUrl(l.link) == false) continue;
+                if (isInternalUrl(l) == false) continue;
                 if (l.link.empty())
                 {
                     nremptylinks++;
@@ -198,7 +198,7 @@ void test_articles(const zim::Archive& archive, ErrorLogger& reporter, ProgressB
 
             for (auto &l: links)
             {
-                if (l.attribute == "src" && isExternalUrl(l.link))
+                if (l.attribute == "src" && isExternalUrl(l))
                 {
                     std::ostringstream ss;
                     ss << l.link << " is an external dependence in article " << path;

--- a/src/zimcheck/checks.cpp
+++ b/src/zimcheck/checks.cpp
@@ -1,7 +1,6 @@
 #include "checks.h"
 #include "../tools.h"
 
-#include <regex>
 #include <map>
 #include <unordered_map>
 #include <list>
@@ -9,29 +8,6 @@
 #define ZIM_PRIVATE
 #include <zim/archive.h>
 #include <zim/item.h>
-
-inline bool isDataUrl(const std::string& input_string)
-{
-    static std::regex data_url_regex =
-      std::regex("data:.+", std::regex_constants::icase);
-    return std::regex_match(input_string, data_url_regex);
-}
-
-inline bool isExternalUrl(const std::string& input_string)
-{
-    // A string starting with "<scheme>://" or "geo:" or "tel:" or "javascript:" or "mailto:"
-    static std::regex external_url_regex =
-      std::regex("([^:/?#]+:\\/\\/|geo:|tel:|mailto:|javascript:).*",
-                 std::regex_constants::icase);
-    return std::regex_match(input_string, external_url_regex);
-}
-
-// Checks if a URL is an internal URL or not. Uses RegExp.
-inline bool isInternalUrl(const std::string& input_string)
-{
-    return !isExternalUrl(input_string) && !isDataUrl(input_string);
-}
-
 
 void test_checksum(zim::Archive& archive, ErrorLogger& reporter) {
     std::cout << "[INFO] Verifying Internal Checksum..." << std::endl;

--- a/src/zimcheck/checks.cpp
+++ b/src/zimcheck/checks.cpp
@@ -142,7 +142,7 @@ void test_articles(const zim::Archive& archive, ErrorLogger& reporter, ProgressB
             for (const auto &l : links)
             {
                 if (l.link.front() == '#' || l.link.front() == '?') continue;
-                if (isInternalUrl(l) == false) continue;
+                if (l.isInternalUrl() == false) continue;
                 if (l.link.empty())
                 {
                     nremptylinks++;
@@ -195,7 +195,7 @@ void test_articles(const zim::Archive& archive, ErrorLogger& reporter, ProgressB
         {
             for (const auto &l: links)
             {
-                if (l.attribute == "src" && isExternalUrl(l))
+                if (l.attribute == "src" && l.isExternalUrl())
                 {
                     std::ostringstream ss;
                     ss << l.link << " is an external dependence in article " << path;

--- a/src/zimcheck/checks.cpp
+++ b/src/zimcheck/checks.cpp
@@ -193,10 +193,7 @@ void test_articles(const zim::Archive& archive, ErrorLogger& reporter, ProgressB
 
         if (url_check_external)
         {
-            if (item.getMimetype() != "text/html")
-                continue;
-
-            for (auto &l: links)
+            for (const auto &l: links)
             {
                 if (l.attribute == "src" && isExternalUrl(l))
                 {

--- a/test/tools-test.cpp
+++ b/test/tools-test.cpp
@@ -153,23 +153,23 @@ TEST(tools, uriKind)
     EXPECT_EQ(UriKind::DATA, uriKind("data:text/plain;charset=UTF-8,data"));
     EXPECT_EQ(UriKind::DATA, uriKind("DATA:text/plain;charset=UTF-8,data"));
 
-    EXPECT_EQ(UriKind::INVALID, uriKind("http:example.com"));
-    EXPECT_EQ(UriKind::INVALID, uriKind("http:/example.com"));
-    EXPECT_EQ(UriKind::INVALID, uriKind("git@github.com:openzim/zim-tools.git"));
-    EXPECT_EQ(UriKind::INVALID, uriKind("/redirect?url=http://example.com"));
-    EXPECT_EQ(UriKind::INVALID, uriKind("redirect?url=http://example.com"));
-    EXPECT_EQ(UriKind::INVALID, uriKind("auth.php#returnurl=https://example.com"));
-    EXPECT_EQ(UriKind::INVALID, uriKind("/api/v1/http://example.com"));
-    EXPECT_EQ(UriKind::INVALID, uriKind("img/file:///etc/passwd"));
-    EXPECT_EQ(UriKind::INVALID, uriKind("ftp:/download.kiwix.org/zim/"));
-    EXPECT_EQ(UriKind::INVALID, uriKind("sendmailto:someone@example.com"));
-    EXPECT_EQ(UriKind::INVALID, uriKind("intel:+0123456789"));
-    EXPECT_EQ(UriKind::INVALID, uriKind("showlocation.cgi?geo:12.34,56.78"));
-    EXPECT_EQ(UriKind::INVALID, uriKind("/xyz/javascript:console.log('hello, world!')"));
+    EXPECT_EQ(UriKind::OTHER, uriKind("http:example.com"));
+    EXPECT_EQ(UriKind::OTHER, uriKind("http:/example.com"));
+    EXPECT_EQ(UriKind::OTHER, uriKind("git@github.com:openzim/zim-tools.git"));
+    EXPECT_EQ(UriKind::OTHER, uriKind("/redirect?url=http://example.com"));
+    EXPECT_EQ(UriKind::OTHER, uriKind("redirect?url=http://example.com"));
+    EXPECT_EQ(UriKind::OTHER, uriKind("auth.php#returnurl=https://example.com"));
+    EXPECT_EQ(UriKind::OTHER, uriKind("/api/v1/http://example.com"));
+    EXPECT_EQ(UriKind::OTHER, uriKind("img/file:///etc/passwd"));
+    EXPECT_EQ(UriKind::OTHER, uriKind("ftp:/download.kiwix.org/zim/"));
+    EXPECT_EQ(UriKind::OTHER, uriKind("sendmailto:someone@example.com"));
+    EXPECT_EQ(UriKind::OTHER, uriKind("intel:+0123456789"));
+    EXPECT_EQ(UriKind::OTHER, uriKind("showlocation.cgi?geo:12.34,56.78"));
+    EXPECT_EQ(UriKind::OTHER, uriKind("/xyz/javascript:console.log('hello, world!')"));
 
-    EXPECT_EQ(UriKind::INVALID, uriKind("/api/data:text/plain;charset=UTF-8,qwerty"));
-    EXPECT_EQ(UriKind::INVALID, uriKind("../img/logo.png"));
-    EXPECT_EQ(UriKind::INVALID, uriKind("style.css"));
+    EXPECT_EQ(UriKind::OTHER, uriKind("/api/data:text/plain;charset=UTF-8,qwerty"));
+    EXPECT_EQ(UriKind::OTHER, uriKind("../img/logo.png"));
+    EXPECT_EQ(UriKind::OTHER, uriKind("style.css"));
 }
 
 TEST(tools, isOutofBounds)

--- a/test/tools-test.cpp
+++ b/test/tools-test.cpp
@@ -124,81 +124,47 @@ TEST(CommonTools, stripTitleInvalidChars)
   EXPECT_EQ(str, "header");
 }
 
-TEST(tools, isExternalUrl)
+TEST(tools, uriKind)
 {
-    EXPECT_TRUE (isExternalUrl("http://example.com"));
-    EXPECT_TRUE (isExternalUrl("https://example.com"));
-    EXPECT_TRUE (isExternalUrl("HttP://example.com"));
-    EXPECT_TRUE (isExternalUrl("HtTps://example.com"));
-    EXPECT_TRUE (isExternalUrl("file:///etc/passwd"));
-    EXPECT_TRUE (isExternalUrl("ftp://download.kiwix.org/zim/"));
-    EXPECT_TRUE (isExternalUrl("mailto:someone@example.com"));
-    EXPECT_TRUE (isExternalUrl("MAILTO:someone@example.com"));
-    EXPECT_TRUE (isExternalUrl("tel:+0123456789"));
-    EXPECT_TRUE (isExternalUrl("TEL:+0123456789"));
-    EXPECT_TRUE (isExternalUrl("geo:12.34,56.78"));
-    EXPECT_TRUE (isExternalUrl("GEO:12.34,56.78"));
-    EXPECT_TRUE (isExternalUrl("javascript:console.log('hello, world!')"));
-    EXPECT_TRUE (isExternalUrl("JAVAscript:console.log('hello, world!')"));
+    EXPECT_EQ(UriKind::GENERIC_URI, uriKind("http://example.com"));
+    EXPECT_EQ(UriKind::GENERIC_URI, uriKind("https://example.com"));
+    EXPECT_EQ(UriKind::GENERIC_URI, uriKind("HttP://example.com"));
+    EXPECT_EQ(UriKind::GENERIC_URI, uriKind("HtTps://example.com"));
+    EXPECT_EQ(UriKind::GENERIC_URI, uriKind("file:///etc/passwd"));
+    EXPECT_EQ(UriKind::GENERIC_URI, uriKind("ftp://download.kiwix.org/zim/"));
 
-    EXPECT_FALSE(isExternalUrl("http:example.com"));
-    EXPECT_FALSE(isExternalUrl("http:/example.com"));
-    EXPECT_FALSE(isExternalUrl("git@github.com:openzim/zim-tools.git"));
-    EXPECT_FALSE(isExternalUrl("/redirect?url=http://example.com"));
-    EXPECT_FALSE(isExternalUrl("redirect?url=http://example.com"));
-    EXPECT_FALSE(isExternalUrl("auth.php#returnurl=https://example.com"));
-    EXPECT_FALSE(isExternalUrl("/api/v1/http://example.com"));
-    EXPECT_FALSE(isExternalUrl("img/file:///etc/passwd"));
-    EXPECT_FALSE(isExternalUrl("ftp:/download.kiwix.org/zim/"));
-    EXPECT_FALSE(isExternalUrl("sendmailto:someone@example.com"));
-    EXPECT_FALSE(isExternalUrl("intel:+0123456789"));
-    EXPECT_FALSE(isExternalUrl("showlocation.cgi?geo:12.34,56.78"));
-    EXPECT_FALSE(isExternalUrl("/xyz/javascript:console.log('hello, world!')"));
+    EXPECT_EQ(UriKind::MAILTO, uriKind("mailto:someone@example.com"));
+    EXPECT_EQ(UriKind::MAILTO, uriKind("MAILTO:someone@example.com"));
 
-    EXPECT_FALSE(isExternalUrl("data:text/plain;charset=UTF-8,the%20data"));
-    EXPECT_FALSE(isExternalUrl("DATA:text/plain;charset=UTF-8,the%20data"));
-    EXPECT_FALSE(isExternalUrl("/api/data:text/plain;charset=UTF-8,qwerty"));
-    EXPECT_FALSE(isExternalUrl("../img/logo.png"));
-    EXPECT_FALSE(isExternalUrl("style.css"));
-}
+    EXPECT_EQ(UriKind::TEL, uriKind("tel:+0123456789"));
+    EXPECT_EQ(UriKind::TEL, uriKind("TEL:+0123456789"));
 
-TEST(tools, isInternalUrl)
-{
-    EXPECT_FALSE(isInternalUrl("http://example.com"));
-    EXPECT_FALSE(isInternalUrl("https://example.com"));
-    EXPECT_FALSE(isInternalUrl("HttP://example.com"));
-    EXPECT_FALSE(isInternalUrl("HtTps://example.com"));
-    EXPECT_FALSE(isInternalUrl("file:///etc/passwd"));
-    EXPECT_FALSE(isInternalUrl("ftp://download.kiwix.org/zim/"));
-    EXPECT_FALSE(isInternalUrl("mailto:someone@example.com"));
-    EXPECT_FALSE(isInternalUrl("MAILTO:someone@example.com"));
-    EXPECT_FALSE(isInternalUrl("tel:+0123456789"));
-    EXPECT_FALSE(isInternalUrl("TEL:+0123456789"));
-    EXPECT_FALSE(isInternalUrl("geo:12.34,56.78"));
-    EXPECT_FALSE(isInternalUrl("GEO:12.34,56.78"));
-    EXPECT_FALSE(isInternalUrl("javascript:console.log('hello, world!')"));
-    EXPECT_FALSE(isInternalUrl("JAVAscript:console.log('hello, world!')"));
+    EXPECT_EQ(UriKind::GEO, uriKind("geo:12.34,56.78"));
+    EXPECT_EQ(UriKind::GEO, uriKind("GEO:12.34,56.78"));
 
-    EXPECT_FALSE(isInternalUrl("data:text/plain;charset=UTF-8,the%20data"));
-    EXPECT_FALSE(isInternalUrl("DATA:text/plain;charset=UTF-8,the%20data"));
+    EXPECT_EQ(UriKind::JAVASCRIPT, uriKind("javascript:console.log('hello!')"));
+    EXPECT_EQ(UriKind::JAVASCRIPT, uriKind("JAVAscript:console.log('hello!')"));
 
-    EXPECT_TRUE (isInternalUrl("http:example.com"));
-    EXPECT_TRUE (isInternalUrl("http:/example.com"));
-    EXPECT_TRUE (isInternalUrl("git@github.com:openzim/zim-tools.git"));
-    EXPECT_TRUE (isInternalUrl("/redirect?url=http://example.com"));
-    EXPECT_TRUE (isInternalUrl("redirect?url=http://example.com"));
-    EXPECT_TRUE (isInternalUrl("auth.php#returnurl=https://example.com"));
-    EXPECT_TRUE (isInternalUrl("/api/v1/http://example.com"));
-    EXPECT_TRUE (isInternalUrl("img/file:///etc/passwd"));
-    EXPECT_TRUE (isInternalUrl("ftp:/download.kiwix.org/zim/"));
-    EXPECT_TRUE (isInternalUrl("sendmailto:someone@example.com"));
-    EXPECT_TRUE (isInternalUrl("intel:+0123456789"));
-    EXPECT_TRUE (isInternalUrl("showlocation.cgi?geo:12.34,56.78"));
-    EXPECT_TRUE (isInternalUrl("/xyz/javascript:console.log('hello, world!')"));
+    EXPECT_EQ(UriKind::DATA, uriKind("data:text/plain;charset=UTF-8,data"));
+    EXPECT_EQ(UriKind::DATA, uriKind("DATA:text/plain;charset=UTF-8,data"));
 
-    EXPECT_TRUE (isInternalUrl("/api/data:text/plain;charset=UTF-8,qwerty"));
-    EXPECT_TRUE (isInternalUrl("../img/logo.png"));
-    EXPECT_TRUE (isInternalUrl("style.css"));
+    EXPECT_EQ(UriKind::INVALID, uriKind("http:example.com"));
+    EXPECT_EQ(UriKind::INVALID, uriKind("http:/example.com"));
+    EXPECT_EQ(UriKind::INVALID, uriKind("git@github.com:openzim/zim-tools.git"));
+    EXPECT_EQ(UriKind::INVALID, uriKind("/redirect?url=http://example.com"));
+    EXPECT_EQ(UriKind::INVALID, uriKind("redirect?url=http://example.com"));
+    EXPECT_EQ(UriKind::INVALID, uriKind("auth.php#returnurl=https://example.com"));
+    EXPECT_EQ(UriKind::INVALID, uriKind("/api/v1/http://example.com"));
+    EXPECT_EQ(UriKind::INVALID, uriKind("img/file:///etc/passwd"));
+    EXPECT_EQ(UriKind::INVALID, uriKind("ftp:/download.kiwix.org/zim/"));
+    EXPECT_EQ(UriKind::INVALID, uriKind("sendmailto:someone@example.com"));
+    EXPECT_EQ(UriKind::INVALID, uriKind("intel:+0123456789"));
+    EXPECT_EQ(UriKind::INVALID, uriKind("showlocation.cgi?geo:12.34,56.78"));
+    EXPECT_EQ(UriKind::INVALID, uriKind("/xyz/javascript:console.log('hello, world!')"));
+
+    EXPECT_EQ(UriKind::INVALID, uriKind("/api/data:text/plain;charset=UTF-8,qwerty"));
+    EXPECT_EQ(UriKind::INVALID, uriKind("../img/logo.png"));
+    EXPECT_EQ(UriKind::INVALID, uriKind("style.css"));
 }
 
 TEST(tools, isOutofBounds)

--- a/test/tools-test.cpp
+++ b/test/tools-test.cpp
@@ -124,6 +124,11 @@ TEST(CommonTools, stripTitleInvalidChars)
   EXPECT_EQ(str, "header");
 }
 
+UriKind uriKind(const std::string& s)
+{
+    return html_link::detectUriKind(s);
+}
+
 TEST(tools, uriKind)
 {
     EXPECT_EQ(UriKind::GENERIC_URI, uriKind("http://example.com"));

--- a/test/tools-test.cpp
+++ b/test/tools-test.cpp
@@ -124,14 +124,6 @@ TEST(CommonTools, stripTitleInvalidChars)
   EXPECT_EQ(str, "header");
 }
 
-TEST(tools, isDataUrl)
-{
-    EXPECT_TRUE (isDataUrl("data:text/plain;charset=UTF-8,the%20data"));
-    EXPECT_TRUE (isDataUrl("DATA:text/plain;charset=UTF-8,the%20data"));
-
-    EXPECT_FALSE(isDataUrl("/api/data:text/plain;charset=UTF-8,the%20data"));
-}
-
 TEST(tools, isExternalUrl)
 {
     EXPECT_TRUE (isExternalUrl("http://example.com"));

--- a/test/tools-test.cpp
+++ b/test/tools-test.cpp
@@ -124,6 +124,91 @@ TEST(CommonTools, stripTitleInvalidChars)
   EXPECT_EQ(str, "header");
 }
 
+TEST(tools, isDataUrl)
+{
+    EXPECT_TRUE (isDataUrl("data:text/plain;charset=UTF-8,the%20data"));
+    EXPECT_TRUE (isDataUrl("DATA:text/plain;charset=UTF-8,the%20data"));
+
+    EXPECT_FALSE(isDataUrl("/api/data:text/plain;charset=UTF-8,the%20data"));
+}
+
+TEST(tools, isExternalUrl)
+{
+    EXPECT_TRUE (isExternalUrl("http://example.com"));
+    EXPECT_TRUE (isExternalUrl("https://example.com"));
+    EXPECT_TRUE (isExternalUrl("HttP://example.com"));
+    EXPECT_TRUE (isExternalUrl("HtTps://example.com"));
+    EXPECT_TRUE (isExternalUrl("file:///etc/passwd"));
+    EXPECT_TRUE (isExternalUrl("ftp://download.kiwix.org/zim/"));
+    EXPECT_TRUE (isExternalUrl("mailto:someone@example.com"));
+    EXPECT_TRUE (isExternalUrl("MAILTO:someone@example.com"));
+    EXPECT_TRUE (isExternalUrl("tel:+0123456789"));
+    EXPECT_TRUE (isExternalUrl("TEL:+0123456789"));
+    EXPECT_TRUE (isExternalUrl("geo:12.34,56.78"));
+    EXPECT_TRUE (isExternalUrl("GEO:12.34,56.78"));
+    EXPECT_TRUE (isExternalUrl("javascript:console.log('hello, world!')"));
+    EXPECT_TRUE (isExternalUrl("JAVAscript:console.log('hello, world!')"));
+
+    EXPECT_FALSE(isExternalUrl("http:example.com"));
+    EXPECT_FALSE(isExternalUrl("http:/example.com"));
+    EXPECT_FALSE(isExternalUrl("git@github.com:openzim/zim-tools.git"));
+    EXPECT_FALSE(isExternalUrl("/redirect?url=http://example.com"));
+    EXPECT_FALSE(isExternalUrl("redirect?url=http://example.com"));
+    EXPECT_FALSE(isExternalUrl("auth.php#returnurl=https://example.com"));
+    EXPECT_FALSE(isExternalUrl("/api/v1/http://example.com"));
+    EXPECT_FALSE(isExternalUrl("img/file:///etc/passwd"));
+    EXPECT_FALSE(isExternalUrl("ftp:/download.kiwix.org/zim/"));
+    EXPECT_FALSE(isExternalUrl("sendmailto:someone@example.com"));
+    EXPECT_FALSE(isExternalUrl("intel:+0123456789"));
+    EXPECT_FALSE(isExternalUrl("showlocation.cgi?geo:12.34,56.78"));
+    EXPECT_FALSE(isExternalUrl("/xyz/javascript:console.log('hello, world!')"));
+
+    EXPECT_FALSE(isExternalUrl("data:text/plain;charset=UTF-8,the%20data"));
+    EXPECT_FALSE(isExternalUrl("DATA:text/plain;charset=UTF-8,the%20data"));
+    EXPECT_FALSE(isExternalUrl("/api/data:text/plain;charset=UTF-8,qwerty"));
+    EXPECT_FALSE(isExternalUrl("../img/logo.png"));
+    EXPECT_FALSE(isExternalUrl("style.css"));
+}
+
+TEST(tools, isInternalUrl)
+{
+    EXPECT_FALSE(isInternalUrl("http://example.com"));
+    EXPECT_FALSE(isInternalUrl("https://example.com"));
+    EXPECT_FALSE(isInternalUrl("HttP://example.com"));
+    EXPECT_FALSE(isInternalUrl("HtTps://example.com"));
+    EXPECT_FALSE(isInternalUrl("file:///etc/passwd"));
+    EXPECT_FALSE(isInternalUrl("ftp://download.kiwix.org/zim/"));
+    EXPECT_FALSE(isInternalUrl("mailto:someone@example.com"));
+    EXPECT_FALSE(isInternalUrl("MAILTO:someone@example.com"));
+    EXPECT_FALSE(isInternalUrl("tel:+0123456789"));
+    EXPECT_FALSE(isInternalUrl("TEL:+0123456789"));
+    EXPECT_FALSE(isInternalUrl("geo:12.34,56.78"));
+    EXPECT_FALSE(isInternalUrl("GEO:12.34,56.78"));
+    EXPECT_FALSE(isInternalUrl("javascript:console.log('hello, world!')"));
+    EXPECT_FALSE(isInternalUrl("JAVAscript:console.log('hello, world!')"));
+
+    EXPECT_FALSE(isInternalUrl("data:text/plain;charset=UTF-8,the%20data"));
+    EXPECT_FALSE(isInternalUrl("DATA:text/plain;charset=UTF-8,the%20data"));
+
+    EXPECT_TRUE (isInternalUrl("http:example.com"));
+    EXPECT_TRUE (isInternalUrl("http:/example.com"));
+    EXPECT_TRUE (isInternalUrl("git@github.com:openzim/zim-tools.git"));
+    EXPECT_TRUE (isInternalUrl("/redirect?url=http://example.com"));
+    EXPECT_TRUE (isInternalUrl("redirect?url=http://example.com"));
+    EXPECT_TRUE (isInternalUrl("auth.php#returnurl=https://example.com"));
+    EXPECT_TRUE (isInternalUrl("/api/v1/http://example.com"));
+    EXPECT_TRUE (isInternalUrl("img/file:///etc/passwd"));
+    EXPECT_TRUE (isInternalUrl("ftp:/download.kiwix.org/zim/"));
+    EXPECT_TRUE (isInternalUrl("sendmailto:someone@example.com"));
+    EXPECT_TRUE (isInternalUrl("intel:+0123456789"));
+    EXPECT_TRUE (isInternalUrl("showlocation.cgi?geo:12.34,56.78"));
+    EXPECT_TRUE (isInternalUrl("/xyz/javascript:console.log('hello, world!')"));
+
+    EXPECT_TRUE (isInternalUrl("/api/data:text/plain;charset=UTF-8,qwerty"));
+    EXPECT_TRUE (isInternalUrl("../img/logo.png"));
+    EXPECT_TRUE (isInternalUrl("style.css"));
+}
+
 TEST(tools, isOutofBounds)
 {
     ASSERT_FALSE(isOutofBounds("", ""));


### PR DESCRIPTION
It turned out that `isExternalUrl()` is a real bottleneck in `zimcheck`. In a `zimcheck -A wikipedia_hy_all_mini_2020-08.zim` benchmark it was responsible for more than 40% of the total runtime. This PR decreases the total runtime of that flow from 338 seconds to 197 seconds.