### PR TITLE
Speed-up of redundant article check in zimcheck

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -387,7 +387,7 @@ bool isOutofBounds(const std::string& input, std::string base)
     return nrsteps >= (nr + std::count(base.cbegin(), base.cend(), '/'));
 }
 
-int adler32(std::string buf)
+int adler32(const std::string& buf)
 {
     unsigned int s1 = 1;
     unsigned int s2 = 0;

--- a/src/tools.h
+++ b/src/tools.h
@@ -95,7 +95,7 @@ bool isOutofBounds(const std::string& input, std::string base);
 
 //Adler32 Hash Function. Used to hash the BLOB data obtained from each article, for redundancy checks.
 //Please note that the adler32 hash function has a high number of collisions, and that the hash match is not taken as final.
-int adler32(std::string buf);
+int adler32(const std::string& buf);
 
 //Removes extra spaces from URLs. Usually done by the browser, so web authors sometimes tend to ignore it.
 //Converts the %20 to space.Essential for comparing URLs.


### PR DESCRIPTION
Fixes #166 

This PR eliminates quadratic complexity of checking for redundant articles in a group of identical articles. It doesn't make sense to report every redundant pair due to the transitivity property of the redundancy relation: if A and B are redundant as well as A and C are redundant, then B and C are also redundant but the latter pair is neither checked nor reported.

Without this fix redundant article check has been running on `wikipedia_arz_all_maxi_2020-10.zim` for more than 2 hours and was evidently stuck on a large set of identical articles:

```
$ zimcheck -b -D wikipedia_arz_all_maxi_2020-10.zim
[INFO] Checking zim file ../zimfiles2/wikipedia_arz_all_maxi_2020-10.zim
[INFO] Verifying Internal Checksum...
[INFO] Searching for metadata entries...
[INFO] Searching for Favicon...
[INFO] Searching for main page...
[INFO] Verifying Articles' content...
1654364/1654364                             # got past here in about half an hour
[INFO] Searching for redundant articles...
  Verifying Similar Articles for redundancies...
25192/1627302                                 # stuck here for about 2 hours
```

With this fix the same flow completed in 2191 seconds.