### PR TITLE
zimcheck --integrity

### DIFF
--- a/src/zimcheck/checks.cpp
+++ b/src/zimcheck/checks.cpp
@@ -44,6 +44,17 @@ void test_checksum(zim::File& f, ErrorLogger& reporter) {
     }
 }
 
+void test_integrity(const std::string& filename, ErrorLogger& reporter) {
+    std::cout << "[INFO] Verifying ZIM-file structure integrity..." << std::endl;
+    zim::IntegrityCheckList checks;
+    checks.set(); // enable all checks (including checksum)
+    bool result = zim::validate(filename, checks);
+    reporter.setTestResult(TestType::INTEGRITY, result);
+    if (!result) {
+        std::cout << "  [ERROR] ZIM file's low level structure is invalid" << std::endl;
+    }
+}
+
 
 void test_metadata(const zim::File& f, ErrorLogger& reporter) {
     std::cout << "[INFO] Searching for metadata entries..." << std::endl;

--- a/src/zimcheck/checks.h
+++ b/src/zimcheck/checks.h
@@ -28,6 +28,7 @@ static std::unordered_map<LogTag, std::string> tagToStr{ {LogTag::ERROR,     "ER
 
 enum class TestType {
     CHECKSUM,
+    INTEGRITY,
     EMPTY,
     METADATA,
     FAVICON,
@@ -48,6 +49,7 @@ namespace std {
 
 static std::unordered_map<TestType, std::pair<LogTag, std::string>> errormapping = {
     { TestType::CHECKSUM,      {LogTag::ERROR, "Invalid checksum"}},
+    { TestType::INTEGRITY,     {LogTag::ERROR, "Invalid low-level structure"}},
     { TestType::EMPTY,         {LogTag::ERROR, "Empty articles"}},
     { TestType::METADATA,      {LogTag::ERROR, "Missing metadata entries"}},
     { TestType::FAVICON,       {LogTag::ERROR, "Missing favicon"}},
@@ -104,6 +106,7 @@ class ErrorLogger {
 
 
 void test_checksum(zim::File& f, ErrorLogger& reporter);
+void test_integrity(const std::string& filename, ErrorLogger& reporter);
 void test_metadata(const zim::File& f, ErrorLogger& reporter);
 void test_favicon(const zim::File& f, ErrorLogger& reporter);
 void test_mainpage(const zim::File& f, ErrorLogger& reporter);


### PR DESCRIPTION
Fixes #184 

Added support for low-level ZIM structure integrity checks performed by `zim::validate()` function.