### PR TITLE
Fixes #172: add M/Packer metadata with content "zimwriterfs-<VERSION>"

### DIFF
--- a/src/zimwriterfs/zimwriterfs.cpp
+++ b/src/zimwriterfs/zimwriterfs.cpp
@@ -47,7 +47,7 @@ std::string publisher;
 std::string title;
 std::string tags;
 std::string flavour;
-std::string scraper;
+std::string scraper = "zimwriterfs-" VERSION;
 std::string name;
 std::string source;
 std::string description;


### PR DESCRIPTION
 Fixes #172: use "zimwriterfs-<VERSION>" as the default value of M/Scraper metadata:

Test: after pack and unpack a direrectory:
```
$ cat res_test/M/Scraper
zimwriterfs-2.0.0
```
