### PR TITLE
Compile zimsearch only if libzim is compiled with xapian support.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -17,6 +17,7 @@ if static_linkage
 endif
 
 libzim_dep = dependency('libzim', version : '>=6.3.0', static:static_linkage)
+with_xapian_support = compiler.has_header_symbol('zim/zim.h', 'LIBZIM_WITH_XAPIAN')
 
 find_library_in_compiler = meson.version().version_compare('>=0.31.0')
 rt_dep = dependency('rt', required:false)

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,7 +1,11 @@
 
-executable('zimsearch', 'zimsearch.cpp',
-  dependencies: libzim_dep,
-  install: true)
+if with_xapian_support
+  executable('zimsearch', 'zimsearch.cpp',
+    dependencies: libzim_dep,
+    install: true)
+else
+  message('Libzim seems to be compiled without xapian support.\nzimsearch will not be compiled.')
+endif
 
 # [FIXME] There are some problem with clock_gettime and mingw.
 if target_machine.system() != 'windows'


### PR DESCRIPTION
Depends of https://github.com/openzim/libzim/pull/465