### PR TITLE
Better openzim/zim-tools image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,26 @@
+name: Docker
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-push:
+    name: Deploy Docker Image
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and push
+        uses: openzim/docker-publish-action@v3
+        with:
+          image-path: openzim/zim-tools
+          tag-pattern: /^([0-9.]+)$/
+          latest-on-tag: true
+          restrict-to: openzim/zim-tools
+          dockerfile: docker/Dockerfile
+          build-args:
+            VERSION: {version}
+          hub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          hub-password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          ghcr-username: ${{ secrets.GHCR_USERNAME }}
+          ghcr-token: ${{ secrets.GHCR_TOKEN }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,48 +1,12 @@
-FROM ubuntu:focal
+ARG VERSION=
+FROM alpine:3
+ARG VERSION
+LABEL org.opencontainers.image.source https://github.com/openzim/zim-tools
+RUN echo "Build image for version: $VERSION"
 
-# Update system
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+RUN wget -O zim-tools.tar.gz -q https://download.openzim.org/release/zim-tools/zim-tools_linux-x86_64-$VERSION.tar.gz && \
+  tar -xzf zim-tools.tar.gz && \
+  cp zim-tools*/* /usr/local/bin/ && \
+  rm -rf zim-tools*
 
-# Configure locales
-RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends locales && \
-    apt-get clean -y && \
-    rm -rf /var/lib/apt/lists/*
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-RUN locale-gen en_US.UTF-8
-
-# Install necessary packages
-RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends git pkg-config libtool automake autoconf make g++ liblzma-dev libzstd-dev coreutils meson ninja-build wget zlib1g-dev libicu-dev libgumbo-dev libmagic-dev libdocopt-dev ca-certificates xz-utils cmake && \
-    apt-get clean -y && \
-    rm -rf /var/lib/apt/lists/*
-
-# Update CA certificates
-RUN update-ca-certificates
-
-# Install Xapian (wget zlib1g-dev)
-RUN wget https://oligarchy.co.uk/xapian/1.4.17/xapian-core-1.4.17.tar.xz
-RUN tar xvf xapian-core-1.4.17.tar.xz
-RUN cd xapian-core-1.4.17 && ./configure --prefix=/usr
-RUN cd xapian-core-1.4.17 && make all install
-RUN rm -rf xapian
-
-# Install zimlib (libicu-dev)
-RUN git clone https://github.com/openzim/libzim.git
-RUN cd libzim && git checkout 6.2.2
-RUN cd libzim && meson . build --prefix=/usr
-RUN cd libzim && ninja -C build install
-RUN rm -rf libzim
-
-# Install zimwriterfs (libgumbo-dev libmagic-dev)
-COPY . zim-tools
-RUN ls zim-tools
-RUN export PKG_CONFIG_PATH=/usr/lib64/pkgconfig && cd zim-tools && meson . build --prefix=/usr
-RUN cd zim-tools && ninja -C build install
-RUN rm -rf zim-tools
-ENV LD_LIBRARY_PATH /usr/lib64/
-
-# Boot commands
-CMD zimwriterfs ; /bin/bash
+CMD ["/bin/sh", "-c", "echo 'Welcome to zim-tools! The following binaries are available:' && ls /usr/local/bin/"]


### PR DESCRIPTION
We used to offer a single `openzim/zimwriterfs` image which:

- is named after zimwriterfs alone (although it contains all tools)
- zimwriterfs is sort-of deprecated now
- is a very large image based on Ubuntu and includes compilation tools
- compiles everything from the repo

With this new workflow that releases will trigger we'll get:

- an `openzim/zim-tools` image tagged with the release's tag
- on both dockerhub and ghcr
- using the official binary for that tag

Release can be triggered manually (using GH UI) for any tag, or we can imagine
that kiwix-build triggers it via the API in `build_release_nightly.py`