### PR TITLE
Fixes issue #200 Unable to dump to fs properly a ZIM file

### DIFF
--- a/src/zimdump.cpp
+++ b/src/zimdump.cpp
@@ -417,12 +417,11 @@ int subcmdDump(ZimDumper &app,  std::map<std::string, docopt::value> &args)
     std::string directory = args["--dir"].asString();
 
     if (directory.empty()) {
-              throw std::runtime_error(
-                std::string("Directory cannot be empty."));
+        throw std::runtime_error("Directory cannot be empty.");
     }
 
     if (directory.back() == '/'){
-      directory.pop_back();
+        directory.pop_back();
     }
 
     return subcmdDumpAll(app, directory, redirect, filter);

--- a/src/zimdump.cpp
+++ b/src/zimdump.cpp
@@ -416,7 +416,12 @@ int subcmdDump(ZimDumper &app,  std::map<std::string, docopt::value> &args)
     
     std::string directory = args["--dir"].asString();
 
-    if (*directory.rbegin() == '/'){
+    if (directory.empty()) {
+              throw std::runtime_error(
+                std::string("Directory cannot be empty."));
+    }
+
+    if (directory.back() == '/'){
       directory.pop_back();
     }
 

--- a/src/zimdump.cpp
+++ b/src/zimdump.cpp
@@ -53,9 +53,6 @@ std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
 
 inline static void createdir(const std::string &path, const std::string &base)
 {
-    if (path.size() <= 1)
-        return ;
-
     std::size_t position = 0;
     while(position != std::string::npos) {
         position = path.find('/', position+1);
@@ -347,7 +344,7 @@ void ZimDumper::dumpFiles(const std::string& directory, bool symlinkdump, std::f
 #else
             if (symlink(redirectPath.c_str(), full_path.c_str()) != 0) {
               throw std::runtime_error(
-                std::string("Error creating symlink from ") + redirectPath + " to " + full_path);
+                std::string("Error creating symlink from ") + full_path + " to " + redirectPath);
             }
 #endif
         }
@@ -416,7 +413,14 @@ int subcmdDump(ZimDumper &app,  std::map<std::string, docopt::value> &args)
         std::string nspace = args["--ns"].asString();
         filter = [nspace](const char c){ return nspace.at(0) == c; };
     }
-    return subcmdDumpAll(app, args["--dir"].asString(), redirect, filter);
+    
+    std::string directory = args["--dir"].asString();
+
+    if (*directory.rbegin() == '/'){
+      directory.pop_back();
+    }
+
+    return subcmdDumpAll(app, directory, redirect, filter);
 }
 
 int subcmdShow(ZimDumper &app,  std::map<std::string, docopt::value> &args)

--- a/src/zimdump.cpp
+++ b/src/zimdump.cpp
@@ -60,7 +60,7 @@ inline static void createdir(const std::string &path, const std::string &base)
     while(position != std::string::npos) {
         position = path.find('/', position+1);
         if (position != std::string::npos) {
-            std::string fulldir = base + path.substr(0, position);
+            std::string fulldir = base + SEPARATOR + path.substr(0, position);
             #if defined(_WIN32)
             std::wstring wfulldir = converter.from_bytes(fulldir);
             CreateDirectoryW(wfulldir.c_str(), NULL);
@@ -308,8 +308,8 @@ void ZimDumper::dumpFiles(const std::string& directory, bool symlinkdump, std::f
     std::string filename = path;
     auto position = path.find_last_of('/');
     if (position != std::string::npos) {
-        dir = path.substr(0, position);
-        filename = path.substr(position);
+        dir = path.substr(0, position + 1);
+        filename = path.substr(position + 1);
         if (find(pathcache.begin(), pathcache.end(), dir) == pathcache.end()) {
             createdir(dir, directory);
             pathcache.push_back(dir);
@@ -325,7 +325,7 @@ void ZimDumper::dumpFiles(const std::string& directory, bool symlinkdump, std::f
     }
 
     std::stringstream ss;
-    ss << dir << SEPARATOR << filename;
+    ss << dir << filename;
     std::string relative_path = ss.str();
     std::string full_path = directory + SEPARATOR + relative_path;
 


### PR DESCRIPTION
- Fixed redundant separator addition to path.
- Removed `(path.length()<=1)` check in `createdir()` that skipped single character directories.
- Fixed position in substr() inside `createdir()` and `dumpFiles()`.