### PR TITLE
fix(zimdump): add canonical links to redirects

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -507,6 +507,7 @@ std::string httpRedirectHtml(const std::string& redirectUrl)
           "<head>"
           "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\" />"
           "<meta http-equiv=\"refresh\" content=\"0;url=" + encodedurl + "\" />"
+          "<link rel=\"canonical\" href=\"" + encodedurl + "\" />"      
           "</head>"
           "<body></body>"
           "</html>";


### PR DESCRIPTION
Without this search engines crawling unpacked version may produce duplicated results.
It does not cost much to have it, and avoids issues like ones linked below.

Ref.
https://github.com/openzim/mwoffliner/pull/963
https://github.com/ipfs/distributed-wikipedia-mirror/issues/65
https://en.wikipedia.org/wiki/Canonical_link_element

cc @kelson42 