### PR TITLE
More robust `computeRelativePath()`

### DIFF
--- a/src/tools.h
+++ b/src/tools.h
@@ -162,10 +162,10 @@ std::string getMimeTypeForFile(const std::string& basedir, const std::string& fi
 std::string getFileContent(const std::string& path);
 std::string decodeUrl(const std::string& encodedUrl);
 
-// Assuming that path1 and path2 are relative to the same location
-// returns the relative path of path2 from path1
-std::string computeRelativePath(const std::string& path1,
-                                const std::string& path2);
+// Assuming that basePath and targetPath are relative to the same location
+// returns the relative path of targetPath from basePath
+std::string computeRelativePath(const std::string& basePath,
+                                const std::string& targetPath);
 
 std::string computeAbsolutePath(const std::string& path,
                                 const std::string& relativePath);

--- a/test/tools-test.cpp
+++ b/test/tools-test.cpp
@@ -57,17 +57,47 @@ TEST(CommonTools, decodeUrl)
 
 TEST(CommonTools, computeRelativePath)
 {
-  EXPECT_EQ("B", computeRelativePath("A", "B"));
+  EXPECT_EQ("A",  computeRelativePath("A" , "A" ));
+  EXPECT_EQ("..", computeRelativePath("A/", "A" ));
+  EXPECT_EQ("A/", computeRelativePath("A" , "A/"));
+  EXPECT_EQ("./", computeRelativePath("A/", "A/"));
+
+  EXPECT_EQ("B",     computeRelativePath("A" , "B" ));
+  EXPECT_EQ("../B",  computeRelativePath("A/", "B" ));
+  EXPECT_EQ("B/",    computeRelativePath("A" , "B/"));
+  EXPECT_EQ("../B/", computeRelativePath("A/", "B/"));
+
+  EXPECT_EQ("A/B",  computeRelativePath("A" , "A/B" ));
+  EXPECT_EQ("B",    computeRelativePath("A/", "A/B" ));
+  EXPECT_EQ("A/B/", computeRelativePath("A" , "A/B/"));
+  EXPECT_EQ("B/",   computeRelativePath("A/", "A/B/"));
+
+  EXPECT_EQ("..",     computeRelativePath("A/B",  "A" ));
+  EXPECT_EQ("../..",  computeRelativePath("A/B/", "A" ));
+  EXPECT_EQ("../",    computeRelativePath("A/B",  "A/"));
+  EXPECT_EQ("../../", computeRelativePath("A/B/", "A/"));
+
   EXPECT_EQ("B/CD/EFG", computeRelativePath("A", "B/CD/EFG"));
 
   EXPECT_EQ("c", computeRelativePath("dir/b", "dir/c"));
+  EXPECT_EQ("b", computeRelativePath("dir/b", "dir/b"));
+  EXPECT_EQ("b/c", computeRelativePath("dir/b", "dir/b/c"));
+  EXPECT_EQ("..", computeRelativePath("dir/b/c", "dir/b"));
   EXPECT_EQ("subdir/", computeRelativePath("dir/b", "dir/subdir/"));
+  EXPECT_EQ("../", computeRelativePath("dir/subdir/b", "dir/subdir/"));
+  EXPECT_EQ("..", computeRelativePath("dir/subdir/b", "dir/subdir"));
+  EXPECT_EQ("../../", computeRelativePath("dir/subdir/b/c", "dir/subdir/"));
+  EXPECT_EQ("../..", computeRelativePath("dir/subdir/b/c", "dir/subdir"));
   EXPECT_EQ("../c", computeRelativePath("dir/subdir/", "dir/c"));
 
   EXPECT_EQ("../c", computeRelativePath("A/B/f", "A/c"));
   EXPECT_EQ("D/c", computeRelativePath("A/f", "A/D/c"));
 
   EXPECT_EQ("c", computeRelativePath("A/B/f", "A/B/c"));
+  EXPECT_EQ("c", computeRelativePath("A/B/c", "A/B/c"));
+  EXPECT_EQ("c/d", computeRelativePath("A/B/c", "A/B/c/d"));
+  EXPECT_EQ("..", computeRelativePath("A/B/c/d", "A/B/c"));
+  EXPECT_EQ("../..", computeRelativePath("A/B/c/d", "A/B"));
 }
 
 TEST(CommonTools, computeAbsolutePath)


### PR DESCRIPTION
Should fix #227 

I didn't test the fix on the ZIM file provided in the linked issue. Instead the problem was identified via code review. When the two paths in `computeRelativePath()` are the same (or the first one is the path of the directory containing the second one), the unsigned variable `ups` is assigned a value of -1 (which, depending on the platform, underflows to 2³²-1 or 2⁶⁴-1):

https://github.com/openzim/zim-tools/blob/f406219cd974d2a944cccbc72a0da8616d886972/src/tools.cpp#L179-L192

The issue seems obvious enough to avoid downloading a 800MiB file.

Since the inputs to `computeRelativePath()` have a semantics of URLs rather than file system paths, I also added testing (and, therefore, addressed handling) of various edge cases related to the usage of a [trailing slash](https://cdivilly.wordpress.com/2014/03/11/why-trailing-slashes-on-uris-are-important/).