### PR TITLE
Update zim-tools with search iterator rename in libzim

### DIFF
--- a/src/zimsearch.cpp
+++ b/src/zimsearch.cpp
@@ -28,7 +28,7 @@ void printSearchResults(zim::Search& search)
     auto results = search.getResults(0, search.getEstimatedMatches());
     for (auto it = results.begin(); it != results.end(); ++it)
     {
-      std::cout << "article " << it->getIndex() << "\nscore " << it.get_score() << "\t:\t" << it->getTitle() << std::endl;
+      std::cout << "article " << it->getIndex() << "\nscore " << it.getScore() << "\t:\t" << it.getTitle() << std::endl;
     }
 }
 


### PR DESCRIPTION
This pr braces zim-tools for openzim/libzim#563

The search iterator API in libzim has been shifted to camel case. This has to be accommodated here as well.