### PR TITLE
Support for new-style illustrations in zimcheck

### DIFF
--- a/src/zimcheck/checks.cpp
+++ b/src/zimcheck/checks.cpp
@@ -280,7 +280,8 @@ void test_metadata(const zim::Archive& archive, ErrorLogger& reporter) {
 void test_favicon(const zim::Archive& archive, ErrorLogger& reporter) {
     reporter.infoMsg("[INFO] Searching for Favicon...");
 
-    if ( archive.getIllustrationSizes().empty() )
+    const auto illustrationSizes = archive.getIllustrationSizes();
+    if ( illustrationSizes.find(48) == illustrationSizes.end() )
       reporter.addMsg(MsgId::MISSING_FAVICON, {});
 }
 

--- a/src/zimcheck/checks.cpp
+++ b/src/zimcheck/checks.cpp
@@ -279,13 +279,9 @@ void test_metadata(const zim::Archive& archive, ErrorLogger& reporter) {
 
 void test_favicon(const zim::Archive& archive, ErrorLogger& reporter) {
     reporter.infoMsg("[INFO] Searching for Favicon...");
-    static const char* const favicon_paths[] = {"-/favicon.png", "I/favicon.png", "I/favicon", "-/favicon"};
-    for (auto &path: favicon_paths) {
-        if (archive.hasEntryByPath(path)) {
-            return;
-        }
-    }
-    reporter.addMsg(MsgId::MISSING_FAVICON, {});
+
+    if ( archive.getIllustrationSizes().empty() )
+      reporter.addMsg(MsgId::MISSING_FAVICON, {});
 }
 
 void test_mainpage(const zim::Archive& archive, ErrorLogger& reporter) {


### PR DESCRIPTION
Fixes #251

In the current fix, the existence of any new-style illustration results in the favicon check being satisfied. 

Questions:

1. Is it acceptable to trust the `zim::Archive::getIllustrationSizes()` function or `zimcheck` should rather check for the favicons using its own explicit logic?
2. If we decide to trust the `zim::Archive::getIllustrationSizes()` function, should the old code be preserved? Note that `zim::Archive::getIllustrationSizes()` contains the same logic for old-style ZIM archives.
3. Should we check that the size required by the spec is present?