### PR TITLE
Fix compression name following new libzim API.

### DIFF
--- a/src/zimwriterfs/zimwriterfs.cpp
+++ b/src/zimwriterfs/zimwriterfs.cpp
@@ -381,7 +381,7 @@ void create_zim()
             .configNbWorkers(threads)
             .configClusterSize(clusterSize)
             .configIndexing(!withoutFTIndex, language)
-            .configCompression(zstdFlag ? zim::zimcompZstd : zim::zimcompLzma);
+            .configCompression(zstdFlag ? zim::Compression::Zstd : zim::Compression::Lzma);
   if ( noUuid ) {
     zimCreator.setUuid(zim::Uuid());
   }


### PR DESCRIPTION
The compression enum is now a scoped enum.

See openzim/libzim#627