### PR TITLE
zimcheck: Test if the link is empty before testing its content.

### DIFF
--- a/src/zimcheck/checks.cpp
+++ b/src/zimcheck/checks.cpp
@@ -425,13 +425,13 @@ void ArticleChecker::check_internal_links(zim::Item item, const LinkCollection& 
     int nremptylinks = 0;
     for (const auto &l : links)
     {
-        if (l.link.front() == '#' || l.link.front() == '?') continue;
-        if (l.isInternalUrl() == false) continue;
         if (l.link.empty())
         {
             nremptylinks++;
             continue;
         }
+        if (l.link.front() == '#' || l.link.front() == '?') continue;
+        if (l.isInternalUrl() == false) continue;
 
 
         if (isOutofBounds(l.link, baseUrl))


### PR DESCRIPTION
Fix #279