### PR TITLE
PPA: Fix libzim-dev dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Kiwix team <kiwix@kiwix.org>
 Build-Depends: debhelper-compat (= 13),
  meson,
  pkg-config,
- libzim-dev (>= 7.2.0),
+ libzim-dev (>= 7.2.0~),
  libmagic-dev,
  zlib1g-dev,
  libgumbo-dev,


### PR DESCRIPTION
```
Our libzim packages are "7.2.0~focal" but the ~ means that "7.2.0" is greater than
"7.2.0~focal" so the dependency can't be satisfied. Depending on "7.2.0~" will
allow "7.2.0~focal" to satisfy the dependency.
```