### PR TITLE
Small runs of zimcheck are now spreading love

### DIFF
--- a/src/zimcheck/zimcheck.cpp
+++ b/src/zimcheck/zimcheck.cpp
@@ -349,7 +349,16 @@ int zimcheck (const std::vector<const char*>& args)
         const std::chrono::duration<double> runtime(endtime - starttime);
         const long seconds = lround(runtime.count());
         std::ostringstream ss;
-        ss << "[INFO] Total time taken by zimcheck: " << seconds << " seconds.";
+        ss << "[INFO] Total time taken by zimcheck: ";
+        if ( seconds < 3 )
+        {
+          ss << "<3";
+        }
+        else
+        {
+          ss << seconds;
+        }
+        ss << " seconds.";
         error.infoMsg(ss.str());
     }
     catch (const std::exception & e)

--- a/test/zimcheck-test.cpp
+++ b/test/zimcheck-test.cpp
@@ -257,7 +257,7 @@ TEST(zimcheck, integrity_goodzimfile)
         "[INFO] Zimcheck version is " VERSION "\n"
         "[INFO] Verifying ZIM-archive structure integrity..." "\n"
         "[INFO] Overall Test Status: Pass" "\n"
-        "[INFO] Total time taken by zimcheck: 0 seconds." "\n"
+        "[INFO] Total time taken by zimcheck: <3 seconds." "\n"
     );
 
     test_zimcheck_single_option(
@@ -276,7 +276,7 @@ TEST(zimcheck, checksum_goodzimfile)
         "[INFO] Zimcheck version is " VERSION "\n"
         "[INFO] Verifying Internal Checksum..." "\n"
         "[INFO] Overall Test Status: Pass" "\n"
-        "[INFO] Total time taken by zimcheck: 0 seconds." "\n"
+        "[INFO] Total time taken by zimcheck: <3 seconds." "\n"
     );
 
     test_zimcheck_single_option(
@@ -295,7 +295,7 @@ TEST(zimcheck, metadata_goodzimfile)
         "[INFO] Zimcheck version is " VERSION "\n"
         "[INFO] Searching for metadata entries..." "\n"
         "[INFO] Overall Test Status: Pass" "\n"
-        "[INFO] Total time taken by zimcheck: 0 seconds." "\n"
+        "[INFO] Total time taken by zimcheck: <3 seconds." "\n"
     );
 
     test_zimcheck_single_option(
@@ -314,7 +314,7 @@ TEST(zimcheck, favicon_goodzimfile)
         "[INFO] Zimcheck version is " VERSION "\n"
         "[INFO] Searching for Favicon..." "\n"
         "[INFO] Overall Test Status: Pass" "\n"
-        "[INFO] Total time taken by zimcheck: 0 seconds." "\n"
+        "[INFO] Total time taken by zimcheck: <3 seconds." "\n"
     );
 
     test_zimcheck_single_option(
@@ -333,7 +333,7 @@ TEST(zimcheck, mainpage_goodzimfile)
         "[INFO] Zimcheck version is " VERSION "\n"
         "[INFO] Searching for main page..." "\n"
         "[INFO] Overall Test Status: Pass" "\n"
-        "[INFO] Total time taken by zimcheck: 0 seconds." "\n"
+        "[INFO] Total time taken by zimcheck: <3 seconds." "\n"
     );
 
     test_zimcheck_single_option(
@@ -352,7 +352,7 @@ TEST(zimcheck, article_content_goodzimfile)
         "[INFO] Zimcheck version is " VERSION "\n"
         "[INFO] Verifying Articles' content..." "\n"
         "[INFO] Overall Test Status: Pass" "\n"
-        "[INFO] Total time taken by zimcheck: 0 seconds." "\n"
+        "[INFO] Total time taken by zimcheck: <3 seconds." "\n"
     );
 
     test_zimcheck_single_option(
@@ -377,7 +377,7 @@ TEST(zimcheck, redundant_articles_goodzimfile)
         "[INFO] Searching for redundant articles..." "\n"
         "  Verifying Similar Articles for redundancies..." "\n"
         "[INFO] Overall Test Status: Pass" "\n"
-        "[INFO] Total time taken by zimcheck: 0 seconds." "\n"
+        "[INFO] Total time taken by zimcheck: <3 seconds." "\n"
     );
 
     test_zimcheck_single_option(
@@ -396,7 +396,7 @@ TEST(zimcheck, redirect_loop_goodzimfile)
     "[INFO] Zimcheck version is " VERSION "\n"
     "[INFO] Checking for redirect loops..." "\n"
     "[INFO] Overall Test Status: Pass" "\n"
-    "[INFO] Total time taken by zimcheck: 0 seconds." "\n"
+    "[INFO] Total time taken by zimcheck: <3 seconds." "\n"
   );
 
   test_zimcheck_single_option(
@@ -421,7 +421,7 @@ const std::string ALL_CHECKS_OUTPUT_ON_GOODZIMFILE(
       "  Verifying Similar Articles for redundancies..." "\n"
       "[INFO] Checking for redirect loops..." "\n"
       "[INFO] Overall Test Status: Pass" "\n"
-      "[INFO] Total time taken by zimcheck: 0 seconds." "\n"
+      "[INFO] Total time taken by zimcheck: <3 seconds." "\n"
 );
 
 TEST(zimcheck, nooptions_goodzimfile)
@@ -510,7 +510,7 @@ TEST(zimcheck, bad_checksum)
       "  ZIM Archive Checksum in archive: 00000000000000000000000000000000" "\n"
       "" "\n"
       "[INFO] Overall Test Status: Fail" "\n"
-      "[INFO] Total time taken by zimcheck: 0 seconds." "\n"
+      "[INFO] Total time taken by zimcheck: <3 seconds." "\n"
     );
 
     test_zimcheck_single_option(
@@ -532,7 +532,7 @@ TEST(zimcheck, metadata_poorzimfile)
       "  Title" "\n"
       "  Description" "\n"
       "[INFO] Overall Test Status: Fail" "\n"
-      "[INFO] Total time taken by zimcheck: 0 seconds." "\n"
+      "[INFO] Total time taken by zimcheck: <3 seconds." "\n"
     );
 
     test_zimcheck_single_option(
@@ -553,7 +553,7 @@ TEST(zimcheck, favicon_poorzimfile)
       "[ERROR] Favicon:" "\n"
       "  Favicon is missing" "\n"
       "[INFO] Overall Test Status: Fail" "\n"
-      "[INFO] Total time taken by zimcheck: 0 seconds." "\n"
+      "[INFO] Total time taken by zimcheck: <3 seconds." "\n"
     );
 
     test_zimcheck_single_option(
@@ -574,7 +574,7 @@ TEST(zimcheck, mainpage_poorzimfile)
       "[ERROR] Missing mainpage:" "\n"
       "  Main Page Index stored in Archive Header: 4294967295" "\n"
       "[INFO] Overall Test Status: Fail" "\n"
-      "[INFO] Total time taken by zimcheck: 0 seconds." "\n"
+      "[INFO] Total time taken by zimcheck: <3 seconds." "\n"
     );
 
     test_zimcheck_single_option(
@@ -595,7 +595,7 @@ TEST(zimcheck, empty_items_poorzimfile)
       "[ERROR] Empty articles:" "\n"
       "  Entry empty.html is empty" "\n"
       "[INFO] Overall Test Status: Fail" "\n"
-      "[INFO] Total time taken by zimcheck: 0 seconds." "\n"
+      "[INFO] Total time taken by zimcheck: <3 seconds." "\n"
     );
 
     test_zimcheck_single_option(
@@ -620,7 +620,7 @@ TEST(zimcheck, internal_url_check_poorzimfile)
       "  Found 1 empty links in article: empty_link.html" "\n"
       "  ../../oops.html is out of bounds. Article: outofbounds_link.html" "\n"
       "[INFO] Overall Test Status: Fail" "\n"
-      "[INFO] Total time taken by zimcheck: 0 seconds." "\n"
+      "[INFO] Total time taken by zimcheck: <3 seconds." "\n"
     );
 
     test_zimcheck_single_option(
@@ -641,7 +641,7 @@ TEST(zimcheck, external_url_check_poorzimfile)
       "[ERROR] Invalid external links found:" "\n"
       "  http://a.io/pic.png is an external dependence in article external_link.html" "\n"
       "[INFO] Overall Test Status: Fail" "\n"
-      "[INFO] Total time taken by zimcheck: 0 seconds." "\n"
+      "[INFO] Total time taken by zimcheck: <3 seconds." "\n"
     );
 
     test_zimcheck_single_option(
@@ -664,7 +664,7 @@ TEST(zimcheck, redundant_poorzimfile)
       "[WARNING] Redundant data found:" "\n"
       "  article1.html and redundant_article.html" "\n"
       "[INFO] Overall Test Status: Pass" "\n"
-      "[INFO] Total time taken by zimcheck: 0 seconds." "\n"
+      "[INFO] Total time taken by zimcheck: <3 seconds." "\n"
     );
 
     test_zimcheck_single_option(
@@ -690,7 +690,7 @@ TEST(zimcheck, redirect_loop_poorzimfile)
     "  Redirect loop exists from entry redirect_loop3.html" "\n"
     "" "\n"
     "[INFO] Overall Test Status: Fail" "\n"
-    "[INFO] Total time taken by zimcheck: 0 seconds." "\n"
+    "[INFO] Total time taken by zimcheck: <3 seconds." "\n"
   );
 
   test_zimcheck_single_option(
@@ -741,7 +741,7 @@ const std::string ALL_CHECKS_OUTPUT_ON_POORZIMFILE(
       "  Redirect loop exists from entry redirect_loop3.html" "\n"
       "" "\n"
       "[INFO] Overall Test Status: Fail" "\n"
-      "[INFO] Total time taken by zimcheck: 0 seconds." "\n"
+      "[INFO] Total time taken by zimcheck: <3 seconds." "\n"
 );
 
 TEST(zimcheck, nooptions_poorzimfile)


### PR DESCRIPTION
Fixes #287

The unit-tests of zimcheck include a report on the total runtime of each flow. Since those flows are very small the corresponding line from the zimcheck output used to be

    [INFO] Total time taken by zimcheck: 0 seconds.

which corresponds to the duration of the flow being under half a second.

However, Debian builds and tests zimcheck - among other configurations - on virtualized hardware too. The incurred slowdown results in the runtime exceeding the 0.5 second limit whereupon the performance report changes and the unit-tests fail (openzim/zim-tools#287).

The challenge was to come up with a solution meeting the following requirements:

a. no discrimination between fast and (moderately) slow build environments

b. the performance info is preserved in the output and is not excluded from comparison (so that, in the absence of dedicated
   performance testing, it keeps serving as a simple defence against unintended significant slowdown in zimcheck).

Since runtime numbers are mainly justified for large ZIM files, the solution is to report small runtimes as "<X seconds" for some value of X. The latter threshold was set to 3 with the only purpose of further increasing the amount of love in the world.