### PR TITLE
Use "host_machine", not "target_machine" for cross-compilation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -23,7 +23,7 @@ find_library_in_compiler = meson.version().version_compare('>=0.31.0')
 rt_dep = dependency('rt', required:false)
 docopt_dep = dependency('docopt', static:static_linkage)
 
-with_writer = target_machine.system() != 'windows'
+with_writer = host_machine.system() != 'windows'
 
 if with_writer
   thread_dep = dependency('threads')


### PR DESCRIPTION
Read https://mesonbuild.com/Cross-compilation.html for all the rationals.