### PR TITLE
Correctly print the mainpage with zimdump.

### DIFF
--- a/src/zimdump.cpp
+++ b/src/zimdump.cpp
@@ -119,7 +119,7 @@ void ZimDumper::printInfo()
   }
 
   if (m_archive.hasMainEntry()) {
-    std::cout << "main page: " << m_archive.getMainEntry().getPath() << "\n";
+    std::cout << "main page: " << m_archive.getMainEntry().getItem(true).getPath() << "\n";
   } else {
     std::cout << "main page: -\n";
   }


### PR DESCRIPTION
The mainpage stored in new zim files is now a redirection to the "real"
mainpage. Let's resolve the redirect before printing the path.


Fix openzim/zim-tools#294