### PR TITLE
zimcheck: Fix J flag

### DIFF
--- a/src/zimcheck/zimcheck.cpp
+++ b/src/zimcheck/zimcheck.cpp
@@ -132,7 +132,7 @@ int zimcheck (const std::vector<const char*>& args)
             { 0, 0, 0, 0}
         };
         int option_index = 0;
-        int c = getopt_long (argc, const_cast<char**>(argv), "ACIMFPRUXLEDHBVW:acimfpruxledhbvw:0",
+        int c = getopt_long (argc, const_cast<char**>(argv), "ACIJMFPRUXLEDHBVW:acijmfpruxledhbvw:0",
                              long_options, &option_index);
         //c = getopt (argc, argv, "ACMFPRUXED");
         if(c == -1)


### PR DESCRIPTION
Fix for #319 

### Command
```
zimcheck -J wikipedia.zim
```
#### Output:
```
{
  "zimcheck_version" : "3.1.1",
  "checks" : [
    "checksum",
    "integrity",
    "empty",
    "metadata",
    "favicon",
    "main_page",
    "redundant",
    "url_internal",
    "url_external",
    "redirect"
  ],
  "file_name" : "wikipedia.zim",
  "file_uuid" : "96ab7616-7c86-cb4c-424b-11bccd6479b0",
  "status" : true,
  "logs" : [
  ]
}
```