### PR TITLE
Fix and enhance illustration file validation

### DIFF
--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -39,11 +39,6 @@ const bool OPTIONAL  = false;
 const std::string LANGS_REGEXP = "\\w{3}(,\\w{3})*";
 const std::string DATE_REGEXP = R"(\d\d\d\d-\d\d-\d\d)";
 
-// PNG regexp has to be defined in such a tricky way because it includes
-// a NUL character
-const char PNG_REGEXP_DATA[] =  "^\x89\x50\x4e\x47\x0d\x0a\x1a\x0a(.|\\s|\0)+";
-const std::string PNG_REGEXP(PNG_REGEXP_DATA, sizeof(PNG_REGEXP_DATA)-1);
-
 bool matchRegex(const std::string& regexStr, const std::string& text)
 {
   const std::regex regex(regexStr);

--- a/src/metadata_constraints.cpp
+++ b/src/metadata_constraints.cpp
@@ -21,7 +21,7 @@ const Metadata::ReservedMetadataTable reservedMetadataInfoTable = {
     MANDATORY,
     0, // There are no constraints on the illustration metadata size
     0, // in order to avoid decoding it as UTF-8 encoded text
-    PNG_REGEXP
+    ""
   },
 };
 

--- a/src/zimwriterfs/zimwriterfs.cpp
+++ b/src/zimwriterfs/zimwriterfs.cpp
@@ -97,8 +97,28 @@ zim::Metadata makeMetadata() {
   metadata.set("Scraper",         scraper);
   metadata.set("Tags",            tags);
   metadata.set("Date",            generateDate());
-  if ( !illustration.empty() )  {
+
+  if (!illustration.empty()) {
     const auto data = getFileContent(directoryPath + "/" + illustration);
+
+    if (data.length() >= 8) {
+      if (!(data.substr(0, 8) == "\x89\x50\x4e\x47\x0d\x0a\x1a\x0a")) {
+        std::cerr << "Illustration must be a PNG image.\n";
+        exit(1);
+      }
+    }
+
+    // In PNG file, 16-20 is width and 20-24 is height (in big endian order)
+    unsigned int width = (data.c_str()[16] << 24) + (data.c_str()[17] << 16)
+                         + (data.c_str()[18] << 8) + (data.c_str()[19] << 0);
+    unsigned int height = (data.c_str()[20] << 24) + (data.c_str()[21] << 16)
+                          + (data.c_str()[22] << 8) + (data.c_str()[23] << 0);
+
+    if (width != 48 || height != 48) {
+      std::cerr << "Illustration must be 48x48.\n";
+      exit(1);
+    }
+
     metadata.set("Illustration_48x48@1", data);
   }
 


### PR DESCRIPTION
* Read the length & width directly from the png file to validate size.
* Replace the crazy regex with simpler magic number checking.

fix https://github.com/openzim/zim-tools/issues/352