### PR TITLE
Specifying MAGIC environment variable

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,9 +4,10 @@ LABEL org.opencontainers.image.source https://github.com/openzim/zim-tools
 # TARGETPLATFORM is injected by docker build
 ARG TARGETPLATFORM
 ARG VERSION
+ENV MAGIC=/usr/share/misc/magic.mgc
 
 RUN set -e && \
-    apk --no-cache add dumb-init curl && \
+    apk --no-cache add dumb-init curl libmagic && \
     echo "TARGETPLATFORM: $TARGETPLATFORM" && \
     if [ "$TARGETPLATFORM" = "linux/386" ]; then ARCH="i586"; \
     # linux/arm64/v8 points to linux/arm64


### PR DESCRIPTION
Added libmagic explicitly as a way to document that this is a required runtime dependency and because the `MAGIC` environ is meant for it but it was already included indirectly.

See #371 