### PR TITLE
Remove Debian bullseye/Buster from CI/CD

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -16,8 +16,6 @@ jobs:
       matrix:
         distro:
           - debian-unstable
-          - debian-bullseye
-          - debian-buster
           - ubuntu-jammy
           - ubuntu-focal
     steps:
@@ -46,20 +44,6 @@ jobs:
         if: matrix.distro == 'debian-unstable'
         name: Build package for debian-unstable
         id: build-debian-unstable
-        with:
-          args: --no-sign
-
-      - uses: legoktm/gh-action-build-deb@debian-bullseye
-        if: matrix.distro == 'debian-bullseye'
-        name: Build package for debian-bullseye
-        id: build-debian-bullseye
-        with:
-          args: --no-sign
-
-      - uses: legoktm/gh-action-build-deb@debian-buster
-        if: matrix.distro == 'debian-buster'
-        name: Build package for debian-buster
-        id: build-debian-buster
         with:
           args: --no-sign
 


### PR DESCRIPTION
`zimlib` package has been renamed `libzim` and therefore it's impossible to proper test on "old" and "new" Debian versions as we have only one control file.