### PR TITLE
Multiple CI workflow improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,19 +16,24 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Setup python 3.7
-        uses: actions/setup-python@v1
+
+      - name: Setup python 3.9
+        uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.9'
+
       - name: Install packages
         run: brew install gcovr ninja libmagic
+
       - name: Install python modules
         run: pip3 install meson==0.49.2 pytest
+
       - name: Install deps
         shell: bash
         run: |
           ARCHIVE_NAME=deps2_osx_native_dyn_zim-tools.tar.xz
           wget -O- http://tmp.kiwix.org/ci/${ARCHIVE_NAME} | tar -xJ -C $HOME
+
       - name: Compile
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install deps
         shell: bash
         run: |
-          ARCHIVE_NAME=deps2_osx_native_dyn_zim-tools.tar.xz
+          ARCHIVE_NAME=deps2_macos_native_dyn_zim-tools.tar.xz
           wget -O- http://tmp.kiwix.org/ci/${ARCHIVE_NAME} | tar -xJ -C $HOME
 
       - name: Compile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,16 @@ name: CI
 on: [push]
 
 jobs:
-  Macos:
-    runs-on: macos-11
+  macOS:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-11
+          - macos-12
+          - macos-13
+    runs-on: ${{ matrix.os }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   macOS:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       HOME: /home/runner
     runs-on: ubuntu-22.04
     container:
-      image: "ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:38"
+      image: "ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2023-10-30"
     steps:
     - name: Extract branch name
       shell: bash


### PR DESCRIPTION
* Use latest version of kiwix-build CI images
* Add macos12 and macos13 to CI
* Use latest version of `actions/setup-python` and Python 3.9 (in place of 3.7) for macOS