### PR TITLE
Do not create extra 0 sized file if last part is bigger than expected.

### DIFF
--- a/src/zimsplit.cpp
+++ b/src/zimsplit.cpp
@@ -130,21 +130,10 @@ class ZimSplitter
         zim::offset_type last(0);
         for(auto offset:offsets) {
             auto chunkSize = offset-last;
-            if (chunkSize > maxPartSize) {
-                // One part is bigger than what we want :/
-                // Still have to write it.
-                if (currentPartSize) {
+            if (currentPartSize > 0 && currentPartSize + chunkSize > maxPartSize) {
                     new_file();
-                }
-                copy_out(chunkSize);
-                new_file();
-            } else {
-                if (currentPartSize+chunkSize > maxPartSize) {
-                    // It would be too much to write the current part in the current file.
-                    new_file();
-                }
-                copy_out(chunkSize);
             }
+            copy_out(chunkSize);
             last = offset;
         }
     }

--- a/src/zimsplit.cpp
+++ b/src/zimsplit.cpp
@@ -129,21 +129,21 @@ class ZimSplitter
 
         zim::offset_type last(0);
         for(auto offset:offsets) {
-            auto currentSize = offset-last;
-            if (currentSize > maxPartSize) {
+            auto chunkSize = offset-last;
+            if (chunkSize > maxPartSize) {
                 // One part is bigger than what we want :/
                 // Still have to write it.
                 if (currentPartSize) {
                     new_file();
                 }
-                copy_out(currentSize);
+                copy_out(chunkSize);
                 new_file();
             } else {
-                if (currentPartSize+currentSize > maxPartSize) {
+                if (currentPartSize+chunkSize > maxPartSize) {
                     // It would be too much to write the current part in the current file.
                     new_file();
                 }
-                copy_out(currentSize);
+                copy_out(chunkSize);
             }
             last = offset;
         }
@@ -156,12 +156,12 @@ class ZimSplitter
 
         zim::offset_type last(0);
         for(auto offset:offsets) {
-            auto currentSize = offset-last;
-            if (currentSize > maxPartSize) {
+            auto chunkSize = offset-last;
+            if (chunkSize > maxPartSize) {
                 // One part is bigger than what we want :/
                 // Still have to write it.
                 std::cout << "The part (probably a cluster) is to big to fit in one part." << std::endl;
-                std::cout << "    size is " << currentSize << "(" << offset << "-" << last << ")." << std::endl;
+                std::cout << "    size is " << chunkSize << "(" << offset << "-" << last << ")." << std::endl;
                 error = true;
             }
             last = offset;

--- a/src/zimsplit.cpp
+++ b/src/zimsplit.cpp
@@ -37,7 +37,7 @@ class ZimSplitter
   private:
     zim::Archive archive;
     const std::string prefix;
-    zim::size_type partSize;
+    zim::size_type maxPartSize;
 
     char first_index, second_index;
 
@@ -48,10 +48,10 @@ class ZimSplitter
     char* batch_buffer;
 
   public:
-    ZimSplitter(const std::string& fname, const std::string& out_prefix, zim::size_type partSize)
+    ZimSplitter(const std::string& fname, const std::string& out_prefix, zim::size_type maxPartSize)
       : archive(fname),
         prefix(out_prefix),
-        partSize(partSize),
+        maxPartSize(maxPartSize),
         first_index(0),
         second_index(0),
         ifile(fname, std::ios::binary),
@@ -80,9 +80,9 @@ class ZimSplitter
     }
 
     void close_file() {
-        if (out_size > partSize) {
+        if (out_size > maxPartSize) {
            std::cout << "WARNING: Part " << part_name << " is bigger that max part size."
-            << " (" << out_size << ">" << partSize << ")" << std::endl;
+            << " (" << out_size << ">" << maxPartSize << ")" << std::endl;
         }
         ofile.close();
     }
@@ -130,7 +130,7 @@ class ZimSplitter
         zim::offset_type last(0);
         for(auto offset:offsets) {
             auto currentSize = offset-last;
-            if (currentSize > partSize) {
+            if (currentSize > maxPartSize) {
                 // One part is bigger than what we want :/
                 // Still have to write it.
                 if (out_size) {
@@ -139,7 +139,7 @@ class ZimSplitter
                 copy_out(currentSize);
                 new_file();
             } else {
-                if (out_size+currentSize > partSize) {
+                if (out_size+currentSize > maxPartSize) {
                     // It would be too much to write the current part in the current file.
                     new_file();
                 }
@@ -157,7 +157,7 @@ class ZimSplitter
         zim::offset_type last(0);
         for(auto offset:offsets) {
             auto currentSize = offset-last;
-            if (currentSize > partSize) {
+            if (currentSize > maxPartSize) {
                 // One part is bigger than what we want :/
                 // Still have to write it.
                 std::cout << "The part (probably a cluster) is to big to fit in one part." << std::endl;

--- a/src/zimsplit.cpp
+++ b/src/zimsplit.cpp
@@ -44,7 +44,7 @@ class ZimSplitter
     std::ifstream ifile;
     std::ofstream ofile;
     std::string part_name;
-    zim::size_type out_size;
+    zim::size_type currentPartSize;
     char* batch_buffer;
 
   public:
@@ -55,7 +55,7 @@ class ZimSplitter
         first_index(0),
         second_index(0),
         ifile(fname, std::ios::binary),
-        out_size(0)
+        currentPartSize(0)
       {
         batch_buffer = new char[BUFFER_SIZE];
     }
@@ -80,9 +80,9 @@ class ZimSplitter
     }
 
     void close_file() {
-        if (out_size > maxPartSize) {
+        if (currentPartSize > maxPartSize) {
            std::cout << "WARNING: Part " << part_name << " is bigger that max part size."
-            << " (" << out_size << ">" << maxPartSize << ")" << std::endl;
+            << " (" << currentPartSize << ">" << maxPartSize << ")" << std::endl;
         }
         ofile.close();
     }
@@ -92,7 +92,7 @@ class ZimSplitter
         part_name = prefix + get_new_suffix();
         std::cout << "opening new file " << part_name << std::endl;
         ofile.open(part_name, std::ios::binary);
-        out_size = 0;
+        currentPartSize = 0;
     }
 
     void copy_out(zim::size_type size) {
@@ -106,7 +106,7 @@ class ZimSplitter
            if (!ofile) {
                throw std::runtime_error("Error while writing zim part");
            }
-           out_size += size_to_copy;
+           currentPartSize += size_to_copy;
            size -= size_to_copy;
         }
     }
@@ -133,13 +133,13 @@ class ZimSplitter
             if (currentSize > maxPartSize) {
                 // One part is bigger than what we want :/
                 // Still have to write it.
-                if (out_size) {
+                if (currentPartSize) {
                     new_file();
                 }
                 copy_out(currentSize);
                 new_file();
             } else {
-                if (out_size+currentSize > maxPartSize) {
+                if (currentPartSize+currentSize > maxPartSize) {
                     // It would be too much to write the current part in the current file.
                     new_file();
                 }


### PR DESCRIPTION
We don't need to open a new file just after we copy out our big part. Yes we will have to open a new file if we have content after but it will be catch correctly by the else two lines above.

But meanwhile, in our big part is the last one, we should not open a new file.

Fix #401 