### PR TITLE
[CHECK] Do not continue with other checks if integrity check fails.

### DIFF
--- a/src/zimcheck/checks.cpp
+++ b/src/zimcheck/checks.cpp
@@ -240,7 +240,7 @@ void test_checksum(zim::Archive& archive, ErrorLogger& reporter) {
     }
 }
 
-void test_integrity(const std::string& filename, ErrorLogger& reporter) {
+bool test_integrity(const std::string& filename, ErrorLogger& reporter) {
     reporter.infoMsg("[INFO] Verifying ZIM-archive structure integrity...");
     zim::IntegrityCheckList checks;
     checks.set(); // enable all checks (including checksum)
@@ -249,6 +249,7 @@ void test_integrity(const std::string& filename, ErrorLogger& reporter) {
     if (!result) {
         reporter.infoMsg("  [ERROR] ZIM file's low level structure is invalid");
     }
+    return result;
 }
 
 

--- a/src/zimcheck/checks.h
+++ b/src/zimcheck/checks.h
@@ -109,7 +109,7 @@ class ErrorLogger {
 
 
 void test_checksum(zim::Archive& archive, ErrorLogger& reporter);
-void test_integrity(const std::string& filename, ErrorLogger& reporter);
+bool test_integrity(const std::string& filename, ErrorLogger& reporter);
 void test_metadata(const zim::Archive& archive, ErrorLogger& reporter);
 void test_favicon(const zim::Archive& archive, ErrorLogger& reporter);
 void test_mainpage(const zim::Archive& archive, ErrorLogger& reporter);

--- a/test/zimcheck-test.cpp
+++ b/test/zimcheck-test.cpp
@@ -274,6 +274,7 @@ TEST(zimcheck, checksum_goodzimfile)
     const std::string expected_output(
         "[INFO] Checking zim file data/zimfiles/good.zim" "\n"
         "[INFO] Zimcheck version is " VERSION "\n"
+        "[WARNING] Integrity check is skipped. Any detected errors may in fact be due to corrupted/invalid data.\n"
         "[INFO] Verifying Internal Checksum..." "\n"
         "[INFO] Overall Test Status: Pass" "\n"
         "[INFO] Total time taken by zimcheck: <3 seconds." "\n"
@@ -293,6 +294,7 @@ TEST(zimcheck, metadata_goodzimfile)
     const std::string expected_output(
         "[INFO] Checking zim file data/zimfiles/good.zim" "\n"
         "[INFO] Zimcheck version is " VERSION "\n"
+        "[WARNING] Integrity check is skipped. Any detected errors may in fact be due to corrupted/invalid data.\n"
         "[INFO] Checking metadata..." "\n"
         "[INFO] Overall Test Status: Pass" "\n"
         "[INFO] Total time taken by zimcheck: <3 seconds." "\n"
@@ -312,6 +314,7 @@ TEST(zimcheck, favicon_goodzimfile)
     const std::string expected_output(
         "[INFO] Checking zim file data/zimfiles/good.zim" "\n"
         "[INFO] Zimcheck version is " VERSION "\n"
+        "[WARNING] Integrity check is skipped. Any detected errors may in fact be due to corrupted/invalid data.\n"
         "[INFO] Searching for Favicon..." "\n"
         "[INFO] Overall Test Status: Pass" "\n"
         "[INFO] Total time taken by zimcheck: <3 seconds." "\n"
@@ -331,6 +334,7 @@ TEST(zimcheck, mainpage_goodzimfile)
     const std::string expected_output(
         "[INFO] Checking zim file data/zimfiles/good.zim" "\n"
         "[INFO] Zimcheck version is " VERSION "\n"
+        "[WARNING] Integrity check is skipped. Any detected errors may in fact be due to corrupted/invalid data.\n"
         "[INFO] Searching for main page..." "\n"
         "[INFO] Overall Test Status: Pass" "\n"
         "[INFO] Total time taken by zimcheck: <3 seconds." "\n"
@@ -350,6 +354,7 @@ TEST(zimcheck, article_content_goodzimfile)
     const std::string expected_output(
         "[INFO] Checking zim file data/zimfiles/good.zim" "\n"
         "[INFO] Zimcheck version is " VERSION "\n"
+        "[WARNING] Integrity check is skipped. Any detected errors may in fact be due to corrupted/invalid data.\n"
         "[INFO] Verifying Articles' content..." "\n"
         "[INFO] Overall Test Status: Pass" "\n"
         "[INFO] Total time taken by zimcheck: <3 seconds." "\n"
@@ -373,6 +378,7 @@ TEST(zimcheck, redundant_articles_goodzimfile)
     const std::string expected_output(
         "[INFO] Checking zim file data/zimfiles/good.zim" "\n"
         "[INFO] Zimcheck version is " VERSION "\n"
+        "[WARNING] Integrity check is skipped. Any detected errors may in fact be due to corrupted/invalid data.\n"
         "[INFO] Verifying Articles' content..." "\n"
         "[INFO] Searching for redundant articles..." "\n"
         "  Verifying Similar Articles for redundancies..." "\n"
@@ -394,6 +400,7 @@ TEST(zimcheck, redirect_loop_goodzimfile)
   const std::string expected_output(
     "[INFO] Checking zim file data/zimfiles/good.zim" "\n"
     "[INFO] Zimcheck version is " VERSION "\n"
+    "[WARNING] Integrity check is skipped. Any detected errors may in fact be due to corrupted/invalid data.\n"
     "[INFO] Checking for redirect loops..." "\n"
     "[INFO] Overall Test Status: Pass" "\n"
     "[INFO] Total time taken by zimcheck: <3 seconds." "\n"
@@ -505,6 +512,7 @@ TEST(zimcheck, bad_checksum)
     const std::string expected_output(
       "[INFO] Checking zim file data/zimfiles/bad_checksum.zim" "\n"
       "[INFO] Zimcheck version is " VERSION "\n"
+      "[WARNING] Integrity check is skipped. Any detected errors may in fact be due to corrupted/invalid data.\n"
       "[INFO] Verifying Internal Checksum..." "\n"
       "  [ERROR] Wrong Checksum in ZIM archive" "\n"
       "[ERROR] Invalid checksum:" "\n"
@@ -528,6 +536,7 @@ TEST(zimcheck, metadata_poorzimfile)
     const std::string expected_stdout(
       "[INFO] Checking zim file data/zimfiles/poor.zim" "\n"
       "[INFO] Zimcheck version is " VERSION "\n"
+      "[WARNING] Integrity check is skipped. Any detected errors may in fact be due to corrupted/invalid data.\n"
       "[INFO] Checking metadata..." "\n"
       "[ERROR] Metadata errors:" "\n"
       "  Missing mandatory metadata: Title" "\n"
@@ -553,6 +562,7 @@ TEST(zimcheck, favicon_poorzimfile)
     const std::string expected_stdout(
       "[INFO] Checking zim file data/zimfiles/poor.zim" "\n"
       "[INFO] Zimcheck version is " VERSION "\n"
+      "[WARNING] Integrity check is skipped. Any detected errors may in fact be due to corrupted/invalid data.\n"
       "[INFO] Searching for Favicon..." "\n"
       "[ERROR] Favicon:" "\n"
       "  Favicon is missing" "\n"
@@ -574,6 +584,7 @@ TEST(zimcheck, mainpage_poorzimfile)
     const std::string expected_stdout(
       "[INFO] Checking zim file data/zimfiles/poor.zim" "\n"
       "[INFO] Zimcheck version is " VERSION "\n"
+      "[WARNING] Integrity check is skipped. Any detected errors may in fact be due to corrupted/invalid data.\n"
       "[INFO] Searching for main page..." "\n"
       "[ERROR] Missing mainpage:" "\n"
       "  Main Page Index stored in Archive Header: 4294967295" "\n"
@@ -595,6 +606,7 @@ TEST(zimcheck, empty_items_poorzimfile)
     const std::string expected_stdout(
       "[INFO] Checking zim file data/zimfiles/poor.zim" "\n"
       "[INFO] Zimcheck version is " VERSION "\n"
+      "[WARNING] Integrity check is skipped. Any detected errors may in fact be due to corrupted/invalid data.\n"
       "[INFO] Verifying Articles' content..." "\n"
       "[ERROR] Empty articles:" "\n"
       "  Entry empty.html is empty" "\n"
@@ -616,6 +628,7 @@ TEST(zimcheck, internal_url_check_poorzimfile)
     const std::string expected_stdout(
       "[INFO] Checking zim file data/zimfiles/poor.zim" "\n"
       "[INFO] Zimcheck version is " VERSION "\n"
+      "[WARNING] Integrity check is skipped. Any detected errors may in fact be due to corrupted/invalid data.\n"
       "[INFO] Verifying Articles' content..." "\n"
       "[ERROR] Invalid internal links found:" "\n"
       "  The following links:" "\n"
@@ -642,6 +655,7 @@ TEST(zimcheck, external_url_check_poorzimfile)
     const std::string expected_stdout(
       "[INFO] Checking zim file data/zimfiles/poor.zim" "\n"
       "[INFO] Zimcheck version is " VERSION "\n"
+      "[WARNING] Integrity check is skipped. Any detected errors may in fact be due to corrupted/invalid data.\n"
       "[INFO] Verifying Articles' content..." "\n"
       "[ERROR] Invalid external links found:" "\n"
       "  http://a.io/pic.png is an external dependence in article external_image_http.html" "\n"
@@ -665,6 +679,7 @@ TEST(zimcheck, redundant_poorzimfile)
     const std::string expected_stdout(
       "[INFO] Checking zim file data/zimfiles/poor.zim" "\n"
       "[INFO] Zimcheck version is " VERSION "\n"
+      "[WARNING] Integrity check is skipped. Any detected errors may in fact be due to corrupted/invalid data.\n"
       "[INFO] Verifying Articles' content..." "\n"
       "[INFO] Searching for redundant articles..." "\n"
       "  Verifying Similar Articles for redundancies..." "\n"
@@ -688,6 +703,7 @@ TEST(zimcheck, redirect_loop_poorzimfile)
   const std::string expected_output(
     "[INFO] Checking zim file data/zimfiles/poor.zim" "\n"
     "[INFO] Zimcheck version is " VERSION "\n"
+    "[WARNING] Integrity check is skipped. Any detected errors may in fact be due to corrupted/invalid data.\n"
     "[INFO] Checking for redirect loops..." "\n"
     "[ERROR] Redirect loop(s) exist:" "\n"
     "  Redirect loop exists from entry redirect_loop.html" "\n"


### PR DESCRIPTION
It make no sense to check content in a zim archive if the zim archive itself is broken and we can't read it.

Fix openzim/libzim#893