### PR TITLE
Do not try to add twice Illustration.

### DIFF
--- a/src/zimrecreate.cpp
+++ b/src/zimrecreate.cpp
@@ -188,7 +188,6 @@ int main(int argc, char* argv[])
 
     //Parsing arguments
     //There will be only two arguments, so no detailed parsing is required.
-    std::cout << "zimrecreate" << std::endl;;
     for(int i=0;i<argc;i++)
     {
         if(std::string(argv[i])=="-H" ||

--- a/src/zimrecreate.cpp
+++ b/src/zimrecreate.cpp
@@ -125,8 +125,9 @@ void create(const std::string& originFilename, const std::string& outFilename, b
   } catch(...) {}
 
   for(auto& metakey:origin.getMetadataKeys()) {
-    if (metakey == "Counter" ) {
+    if (metakey == "Counter" || metakey.find("Illustration_") == 0) {
       // Counter is already added by libzim
+      // Illustration is already handled by `addIllustration`
       continue;
     }
     auto metadata = origin.getMetadata(metakey);


### PR DESCRIPTION
Illustration is already added by `addIllustration` call.
So we must skip the `Illustration_*` metadata.

Fix #418