### PR TITLE
Correctly depends on ICU

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -27,6 +27,7 @@ with_xapian_support = compiler.has_header_symbol('zim/zim.h', 'LIBZIM_WITH_XAPIA
 find_library_in_compiler = meson.version().version_compare('>=0.31.0')
 rt_dep = dependency('rt', required:false)
 docopt_dep = dependency('docopt', static:static_linkage)
+icu_dep = dependency('icu-i18n', static:static_linkage)
 
 with_writer = host_machine.system() != 'windows'
 

--- a/src/zimcheck/meson.build
+++ b/src/zimcheck/meson.build
@@ -23,7 +23,7 @@ executable('zimcheck',
   '../tools.cpp',
   '../metadata.cpp',
   include_directories : inc,
-  dependencies: [libzim_dep, thread_dep],
+  dependencies: [libzim_dep, icu_dep, thread_dep],
   install: true)
 
 

--- a/src/zimwriterfs/meson.build
+++ b/src/zimwriterfs/meson.build
@@ -7,7 +7,7 @@ sources = [
   'zimcreatorfs.cpp'
 ]
 
-deps = [thread_dep, libzim_dep, zlib_dep, gumbo_dep, magic_dep]
+deps = [thread_dep, libzim_dep, zlib_dep, gumbo_dep, magic_dep, icu_dep]
 
 zimwriterfs = executable('zimwriterfs',
                          sources,

--- a/test/meson.build
+++ b/test/meson.build
@@ -21,7 +21,7 @@ if gtest_dep.found() and not meson.is_cross_build()
     foreach test_name : tests
 
         test_exe = executable(test_name, [test_name+'.cpp'] + tests_src_map[test_name],
-                              dependencies : [gtest_dep, libzim_dep, gumbo_dep, magic_dep, zlib_dep],
+                              dependencies : [gtest_dep, libzim_dep, gumbo_dep, magic_dep, zlib_dep, icu_dep],
                               include_directories: inc,
                               build_rpath : '$ORIGIN')
 


### PR DESCRIPTION
`getTextLength` in `metadata.cpp` directly use icu so we must explicitly depend on it.

It was working as libzim wrongly put it in it `libzim.pc` file.
It is not the case anymore with https://github.com/openzim/libzim/pull/91