### PR TITLE
Fix deb CI and clarify minimum libzim version needed

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -15,10 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         distro:
-          - debian-unstable
-          - debian-trixie
-          - debian-bookworm
-          - debian-bullseye
+#          - debian-unstable
+#          - debian-trixie
+#          - debian-bookworm
+#          - debian-bullseye
           - ubuntu-noble
           - ubuntu-jammy
           - ubuntu-focal
@@ -44,33 +44,33 @@ jobs:
           email: release+launchpad@kiwix.org
           distro: ${{ matrix.distro }}
 
-      - uses: legoktm/gh-action-build-deb@debian-unstable
-        if: matrix.distro == 'debian-unstable'
-        name: Build package for debian-unstable
-        id: build-debian-unstable
-        with:
-          args: --no-sign
-
-      - uses: legoktm/gh-action-build-deb@b47978ba8498dc8b8153cc3b5f99a5fc1afa5de1 # pin@debian-trixie
-        if: matrix.distro == 'debian-trixie'
-        name: Build package for debian-trixie
-        id: build-debian-trixie
-        with:
-          args: --no-sign
-
-      - uses: legoktm/gh-action-build-deb@1f4e86a6bb34aaad388167eaf5eb85d553935336 # pin@debian-bookworm
-        if: matrix.distro == 'debian-bookworm'
-        name: Build package for debian-bookworm
-        id: build-debian-bookworm
-        with:
-          args: --no-sign
-
-      - uses: legoktm/gh-action-build-deb@084b4263209252ec80a75d2c78a586192c17f18d # pin@debian-bullseye
-        if: matrix.distro == 'debian-bullseye'
-        name: Build package for debian-bullseye
-        id: build-debian-bullseye
-        with:
-          args: --no-sign
+#      - uses: legoktm/gh-action-build-deb@debian-unstable
+#        if: matrix.distro == 'debian-unstable'
+#        name: Build package for debian-unstable
+#        id: build-debian-unstable
+#        with:
+#          args: --no-sign
+#
+#      - uses: legoktm/gh-action-build-deb@b47978ba8498dc8b8153cc3b5f99a5fc1afa5de1 # pin@debian-trixie
+#        if: matrix.distro == 'debian-trixie'
+#        name: Build package for debian-trixie
+#        id: build-debian-trixie
+#        with:
+#          args: --no-sign
+#
+#      - uses: legoktm/gh-action-build-deb@1f4e86a6bb34aaad388167eaf5eb85d553935336 # pin@debian-bookworm
+#        if: matrix.distro == 'debian-bookworm'
+#        name: Build package for debian-bookworm
+#        id: build-debian-bookworm
+#        with:
+#          args: --no-sign
+#
+#      - uses: legoktm/gh-action-build-deb@084b4263209252ec80a75d2c78a586192c17f18d # pin@debian-bullseye
+#        if: matrix.distro == 'debian-bullseye'
+#        name: Build package for debian-bullseye
+#        id: build-debian-bullseye
+#        with:
+#          args: --no-sign
 
       - uses: legoktm/gh-action-build-deb@9114a536498b65c40b932209b9833aa942bf108d # pin@ubuntu-noble
         if: matrix.distro == 'ubuntu-noble'

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Kiwix team <kiwix@kiwix.org>
 Build-Depends: debhelper-compat (= 13),
  meson,
  pkgconf,
- libzim-dev (>= 9.2.2), libzim-dev (<< 10.0.0),
+ libzim-dev (>= 9.2.0), libzim-dev (<< 10.0.0),
  libmagic-dev,
  zlib1g-dev,
  libgumbo-dev,

--- a/meson.build
+++ b/meson.build
@@ -19,7 +19,7 @@ if static_linkage
   endif
 endif
 
-libzim_dep = dependency('libzim', version:'>=9.2.2', static:static_linkage)
+libzim_dep = dependency('libzim', version:'>=9.2.0', static:static_linkage)
 libzim_dep = dependency('libzim', version:'<10.0.0', static:static_linkage)
 
 with_xapian_support = compiler.has_header_symbol('zim/zim.h', 'LIBZIM_WITH_XAPIAN')


### PR DESCRIPTION
Libzim `9.2.0` is the bare minimum version needed to compile/run the ZIM tools. Unfortunately this is still nowhere available in Debian, so we have to comment-out the CI for Debian packages (but not for Ubuntu)

See https://github.com/openzim/zim-tools/issues/428 for the follow-up on Debian