### PR TITLE
Fix buffer overrun in link normalisation

### DIFF
--- a/test/tools-test.cpp
+++ b/test/tools-test.cpp
@@ -257,8 +257,8 @@ TEST(tools, normalize_link)
 
     // #439: normalized link reading off end of buffer
     // small-string-opt sizes, so sanitizers and valgrind don't pick this up
-    EXPECT_EQ(normalize_link("%", "/"), "/");
-    EXPECT_EQ(normalize_link("%1", ""), "");
+    ASSERT_EQ(normalize_link("%", "/"), "/");
+    ASSERT_EQ(normalize_link("%1", ""), "");
 
     // ../test/tools-test.cpp:260: Failure
     // Expected equality of these values:
@@ -274,8 +274,8 @@ TEST(tools, normalize_link)
 
     // test outside of small-string-opt
     // valgrind will pick up on the error in this one
-    EXPECT_EQ(normalize_link("qrstuvwxyz%", "/abcdefghijklmnop"), "/abcdefghijklmnop/qrstuvwxyz");
-    EXPECT_EQ(normalize_link("qrstuvwxyz%1", "/abcdefghijklmnop"), "/abcdefghijklmnop/qrstuvwxyz");
+    ASSERT_EQ(normalize_link("qrstuvwxyz%", "/abcdefghijklmnop"), "/abcdefghijklmnop/qrstuvwxyz");
+    ASSERT_EQ(normalize_link("qrstuvwxyz%1", "/abcdefghijklmnop"), "/abcdefghijklmnop/qrstuvwxyz");
 }
 
 TEST(tools, addler32)

--- a/test/tools-test.cpp
+++ b/test/tools-test.cpp
@@ -236,6 +236,10 @@ TEST(tools, isOutofBounds)
 
 TEST(tools, normalize_link)
 {
+    ASSERT_EQ(normalize_link("", ""), "");
+    ASSERT_EQ(normalize_link("/", ""), "");
+    ASSERT_EQ(normalize_link("", "/"), "/");
+
     ASSERT_EQ(normalize_link("/a", "/b"), "a");
 
     // not absolute
@@ -250,6 +254,28 @@ TEST(tools, normalize_link)
 
     // URI-decoding is performed
     ASSERT_EQ(normalize_link("/%41%62c", "/"), "Abc");
+
+    // #439: normalized link reading off end of buffer
+    // small-string-opt sizes, so sanitizers and valgrind don't pick this up
+    EXPECT_EQ(normalize_link("%", "/"), "/");
+    EXPECT_EQ(normalize_link("%1", ""), "");
+
+    // ../test/tools-test.cpp:260: Failure
+    // Expected equality of these values:
+    //   normalize_link("%", "/")
+    //     Which is: "/\01bc"
+    //   "/"
+    //
+    // ../test/tools-test.cpp:261: Failure
+    // Expected equality of these values:
+    //   normalize_link("%1", "")
+    //     Which is: "\x1" "1bc"
+    //   ""
+
+    // test outside of small-string-opt
+    // valgrind will pick up on the error in this one
+    EXPECT_EQ(normalize_link("qrstuvwxyz%", "/abcdefghijklmnop"), "/abcdefghijklmnop/qrstuvwxyz");
+    EXPECT_EQ(normalize_link("qrstuvwxyz%1", "/abcdefghijklmnop"), "/abcdefghijklmnop/qrstuvwxyz");
 }
 
 TEST(tools, addler32)
@@ -400,7 +426,6 @@ TEST(tools, getLinks)
       "abcd href = qwerty src={123} xyz",
       ""
     );
-
 }
 #undef EXPECT_LINKS
 


### PR DESCRIPTION
This fixes the buffer overrun issue. I changed the raw `char*` to an iterator and put a couple of bounds checks. First commit updates the normalize_link test which demonstrates the issue with EXPECT. Second commit applies the fix and changes the added tests to be ASSERT.

Closes #439 