### PR TITLE
449 fix off by one

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -450,8 +450,10 @@ std::string normalize_link(const std::string& input, const std::string& baseUrl)
 
         if ( *p == '%')
         {
-            if( (p+3) >= input.cend()){
+            if( (p+2) >= input.cend()){
                 // if the %XX token would go off the end of the string, just break
+                // string::end() returns an iterator pointing to the null terminator
+                // of the underlying c-string (guarenteed as of C++11)
                 break;
             }
             // hhx only officially supports hex unsigned char

--- a/test/tools-test.cpp
+++ b/test/tools-test.cpp
@@ -260,6 +260,9 @@ TEST(tools, normalize_link)
     ASSERT_EQ(normalize_link("%", "/"), "/");
     ASSERT_EQ(normalize_link("%1", ""), "");
 
+    EXPECT_EQ(normalize_link("%26", ""), "&");
+    EXPECT_EQ(normalize_link("%27", "/"), "/\'");
+
     // ../test/tools-test.cpp:260: Failure
     // Expected equality of these values:
     //   normalize_link("%", "/")

--- a/test/tools-test.cpp
+++ b/test/tools-test.cpp
@@ -260,8 +260,8 @@ TEST(tools, normalize_link)
     ASSERT_EQ(normalize_link("%", "/"), "/");
     ASSERT_EQ(normalize_link("%1", ""), "");
 
-    EXPECT_EQ(normalize_link("%26", ""), "&");
-    EXPECT_EQ(normalize_link("%27", "/"), "/\'");
+    ASSERT_EQ(normalize_link("%26", ""), "&");
+    ASSERT_EQ(normalize_link("%27", "/"), "/\'");
 
     // ../test/tools-test.cpp:260: Failure
     // Expected equality of these values:


### PR DESCRIPTION
Fixed the off-by-one error I introduced in normalize_link with `%` parsing and added a couple test cases to verify. 

Closes #449 