### PR TITLE
[RFC] 444 mime types own unit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@
 *.zim
 pip-selfcheck.json
 build/
+*~
+.cache/
+.session/

--- a/src/meson.build
+++ b/src/meson.build
@@ -30,7 +30,7 @@ executable('zimsplit', 'zimsplit.cpp',
   dependencies: [libzim_dep, docopt_dep],
   install: true)
 
-executable('zimrecreate', ['zimrecreate.cpp', 'tools.cpp'],
+executable('zimrecreate', ['zimrecreate.cpp', 'tools.cpp', 'mimetypes.cpp'],
   dependencies: libzim_dep,
   install: true)
 

--- a/src/mimetypes.cpp
+++ b/src/mimetypes.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 Kiwix <kiwix.org>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU  General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#include "mimetypes.h"
+
+namespace {
+
+MimeMap_t create_extMimeTypes()
+{
+    return MimeMap_t{
+        {extHtml      , mimeTextHtml},
+        {extHtm       , mimeTextHtml},
+        {extPng       , mimeImagePng},
+        {extTiff      , mimeImageTiff},
+        {extTif       , mimeImageTiff},
+        {extJpeg      , mimeImageJpeg},
+        {extJpg       , mimeImageJpeg},
+        {extGif       , mimeImageGif},
+        {extSvg       , mimeImageSvgXml},
+        {extTxt       , mimeTextPlain},
+        {extXml       , mimeTextXml},
+        {extEpub      , mimeAppEpubZip},
+        {extPdf       , mimeAppPdf},
+        {extOgg       , mimeAudioOgg},
+        {extOgv       , mimeVideoOgg},
+        {extJs        , mimeAppJavascript},
+        {extJson      , mimeAppJson},
+        {extCss       , mimeTextCss},
+        {extOtf       , mimeFontOtf},
+        {extSfnt      , mimeFontSfnt},
+        {extEot       , mimeAppVndMSFontObj},
+        {extTtf       , mimeFontTtf},
+        {extCollection, mimeFontCollection},
+        {extWoff      , mimeFontWoff},
+        {extWoff2     , mimeFontWoff2},
+        {extVtt       , mimeTextVtt},
+        {extWebm      , mimeVideoWebm},
+        {extWebp      , mimeImageWebp},
+        {extMp4       , mimeVideoMp4},
+        {extDoc       , mimeAppMSWord},
+        {extDocx      , mimeAppVndXmlWord},
+        {extPpt       , mimeAppVndMSPpt},
+        {extOdt       , mimeVndOODoc},
+        {extOdp       , mimeVndOODoc},
+        {extZip       , mimeAppZip},
+        {extWasm      , mimeAppWasm}
+  };
+}
+
+} // namespace
+
+const MimeMap_t& extMimeTypes() {
+    static const MimeMap_t mime = create_extMimeTypes();
+    return mime;
+}
+

--- a/src/mimetypes.h
+++ b/src/mimetypes.h
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2025 Kiwix <kiwix.org>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU  General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#ifndef OPENZIM_TOOLS_MIMETYPES_H
+#define OPENZIM_TOOLS_MIMETYPES_H
+
+#include <map>
+#include <string_view>
+
+inline constexpr std::string_view mimeTextHtml{"text/html"};
+inline constexpr std::string_view mimeImagePng{"image/png"};
+inline constexpr std::string_view mimeImageTiff{"image/tiff"};
+inline constexpr std::string_view mimeImageJpeg{"image/jpeg"};
+inline constexpr std::string_view mimeImageGif{"image/gif"};
+inline constexpr std::string_view mimeImageSvgXml{"image/svg+xml"};
+inline constexpr std::string_view mimeTextPlain{"text/plain"};
+inline constexpr std::string_view mimeTextXml{"text/xml"};
+inline constexpr std::string_view mimeAppEpubZip{"application/epub+zip"};
+inline constexpr std::string_view mimeAppPdf{"application/pdf"};
+inline constexpr std::string_view mimeAudioOgg{"audio/ogg"};
+inline constexpr std::string_view mimeVideoOgg{"video/ogg"};
+inline constexpr std::string_view mimeAppJavascript{"application/javascript"};
+inline constexpr std::string_view mimeAppJson{"application/json"};
+inline constexpr std::string_view mimeTextCss{"text/css"};
+inline constexpr std::string_view mimeFontOtf{"font/otf"};
+inline constexpr std::string_view mimeFontSfnt{"font/sfnt"};
+inline constexpr std::string_view mimeAppVndMSFontObj{"application/vnd.ms-fontobject"};
+inline constexpr std::string_view mimeFontTtf{"font/ttf"};
+inline constexpr std::string_view mimeFontCollection{"font/collection"};
+inline constexpr std::string_view mimeFontWoff{"font/woff"};
+inline constexpr std::string_view mimeFontWoff2{"font/woff2"};
+inline constexpr std::string_view mimeTextVtt{"text/vtt"};
+inline constexpr std::string_view mimeVideoWebm{"video/webm"};
+inline constexpr std::string_view mimeImageWebp{"image/webp"};
+inline constexpr std::string_view mimeVideoMp4{"video/mp4"};
+inline constexpr std::string_view mimeAppMSWord{"application/msword"};
+inline constexpr std::string_view mimeAppVndXmlWord{"application/vnd.openxmlforMats-officedocument.wordprocessingml.document"};
+inline constexpr std::string_view mimeAppVndMSPpt{"application/vnd.ms-powerpoint"};
+inline constexpr std::string_view mimeVndOODoc{"application/vnd.oasis.openDocument.text"};
+inline constexpr std::string_view mimeAppZip{"application/zip"};
+inline constexpr std::string_view mimeAppWasm{"application/wasm"};
+inline constexpr std::string_view mimeAppOctetStream{"application/octet-stream"};
+
+inline constexpr std::string_view mimeAppFontTtf{"application/font-ttf"}; // TODO: in zimcreatorfs but not in table
+inline constexpr std::string_view mimeAppVndMsOpenType{"application/vnd.ms-opentype"}; // TODO: in zimcreatorfs but not in table
+
+inline constexpr std::string_view extHtml       { "html"};
+inline constexpr std::string_view extHtm        { "htm"};
+inline constexpr std::string_view extPng        { "png"};
+inline constexpr std::string_view extTiff       { "tiff"};
+inline constexpr std::string_view extTif        { "tif"};
+inline constexpr std::string_view extJpeg       { "jpeg"};
+inline constexpr std::string_view extJpg        { "jpg"};
+inline constexpr std::string_view extGif        { "gif"};
+inline constexpr std::string_view extSvg        { "svg"};
+inline constexpr std::string_view extTxt        { "txt"};
+inline constexpr std::string_view extXml        { "xml"};
+inline constexpr std::string_view extEpub       { "epub"};
+inline constexpr std::string_view extPdf        { "pdf"};
+inline constexpr std::string_view extOgg        { "ogg"};
+inline constexpr std::string_view extOgv        { "ogv"};
+inline constexpr std::string_view extJs         { "js"};
+inline constexpr std::string_view extJson       { "json"};
+inline constexpr std::string_view extCss        { "css"};
+inline constexpr std::string_view extOtf        { "otf"};
+inline constexpr std::string_view extSfnt       { "sfnt"};
+inline constexpr std::string_view extEot        { "eot"};
+inline constexpr std::string_view extTtf        { "ttf"};
+inline constexpr std::string_view extCollection { "collection"};
+inline constexpr std::string_view extWoff       { "woff"};
+inline constexpr std::string_view extWoff2      { "woff2"};
+inline constexpr std::string_view extVtt        { "vtt"};
+inline constexpr std::string_view extWebm       { "webm"};
+inline constexpr std::string_view extWebp       { "webp"};
+inline constexpr std::string_view extMp4        { "mp4"};
+inline constexpr std::string_view extDoc        { "doc"};
+inline constexpr std::string_view extDocx       { "docx"};
+inline constexpr std::string_view extPpt        { "ppt"};
+inline constexpr std::string_view extOdt        { "odt"};
+inline constexpr std::string_view extOdp        { "odp"};
+inline constexpr std::string_view extZip        { "zip"};
+inline constexpr std::string_view extWasm       { "wasm"};
+
+namespace detail {
+
+// adapted from cppreference example implementation of lexicographical_compare
+struct tolower_str_comparator {
+    using UChar_t = unsigned char;
+
+    static constexpr UChar_t toLower(const UChar_t c) noexcept {
+        constexpr UChar_t offset {'a' - 'A'};
+        return (c <= 'Z' && c >= 'A') ? c + offset : c;
+    }
+
+    static constexpr bool charCompare(UChar_t lhs, UChar_t rhs) noexcept {
+        return toLower(lhs) < toLower(rhs);
+    }
+
+    constexpr bool operator() (const std::string_view lhs, const std::string_view rhs) const noexcept {
+        auto first1 = lhs.cbegin();
+        auto last1 = lhs.cend();
+        auto first2 = rhs.cbegin();
+        auto last2 = rhs.cend();
+
+        for (; (first1 != last1) && (first2 != last2); ++first1, ++first2)
+        {
+            if (charCompare(*first1, *first2)) {
+                return true;
+            }
+            if (charCompare(*first2, *first1)) {
+                return false;
+            }
+        }
+
+        return (first1 == last1) && (first2 != last2);
+    }
+};
+
+} //namespace detail
+
+using MimeMap_t = std::map<std::string_view, const std::string_view, detail::tolower_str_comparator>;
+
+const MimeMap_t& extMimeTypes();
+
+#endif // OPENZIM_TOOLS_MIMETYPES_H

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -18,6 +18,7 @@
  * MA 02110-1301, USA.
  */
 
+#include "mimetypes.h"
 #include "tools.h"
 
 #include <string.h>
@@ -589,6 +590,6 @@ std::string httpRedirectHtml(const std::string& redirectUrl)
 }
 
 bool guess_is_front_article(const std::string& mimetype) {
-  return ( mimetype.find("text/html") == 0
+  return ( mimetype.find(mimeTextHtml) == 0
         && mimetype.find("raw=true") == std::string::npos);
 }

--- a/src/zimcheck/checks.cpp
+++ b/src/zimcheck/checks.cpp
@@ -1,4 +1,6 @@
 #define ZIM_PRIVATE
+
+#include "../mimetypes.h"
 #include "checks.h"
 #include "../tools.h"
 #include "../concurrent_cache.h"
@@ -368,13 +370,13 @@ void ArticleChecker::check_item(const zim::Item& item)
     }
 
     std::string data;
-    if (checks.isEnabled(TestType::REDUNDANT) || item.getMimetype() == "text/html")
+    if (checks.isEnabled(TestType::REDUNDANT) || item.getMimetype() == mimeTextHtml)
         data = item.getData();
 
     if(checks.isEnabled(TestType::REDUNDANT))
         hash_main[adler32(data)].push_back( item.getIndex() );
 
-    if (item.getMimetype() != "text/html")
+    if (item.getMimetype() != mimeTextHtml)
         return;
 
     ArticleChecker::LinkCollection links;

--- a/src/zimdump.cpp
+++ b/src/zimdump.cpp
@@ -35,6 +35,7 @@
 
 #include "version.h"
 #include "tools.h"
+#include "mimetypes.h"
 
 #include <fcntl.h>
 #ifdef _WIN32
@@ -333,7 +334,7 @@ void ZimDumper::dumpFiles(const std::string& directory, bool symlinkdump, std::f
         auto redirectItem = entry.getItem(true);
         std::string redirectPath = redirectItem.getPath();
         redirectPath = computeRelativePath(path, redirectPath);
-        if (symlinkdump == false && redirectItem.getMimetype() == "text/html") {
+        if (symlinkdump == false && redirectItem.getMimetype() == mimeTextHtml) {
             writeHttpRedirect(directory, relative_path, path, redirectPath);
         } else {
 #ifdef _WIN32

--- a/src/zimrecreate.cpp
+++ b/src/zimrecreate.cpp
@@ -28,6 +28,7 @@
 #include <algorithm>
 #include <sstream>
 
+#include "mimetypes.h"
 #include "tools.h"
 #include "version.h"
 
@@ -66,8 +67,8 @@ class PatchItem : public zim::writer::Item
     std::unique_ptr<zim::writer::ContentProvider> getContentProvider() const
     {
         auto mimetype = getMimeType();
-        if ( mimetype.find("text/html") == std::string::npos
-          && mimetype.find("text/css") == std::string::npos) {
+        if ( mimetype.find(mimeTextHtml) == std::string::npos
+          && mimetype.find(mimeTextCss) == std::string::npos) {
             return std::unique_ptr<zim::writer::ContentProvider>(new ItemProvider(item));
         }
 
@@ -132,7 +133,7 @@ void create(const std::string& originFilename, const std::string& outFilename, b
     }
     auto metadata = origin.getMetadata(metakey);
     auto metaProvider = std::unique_ptr<zim::writer::ContentProvider>(new zim::writer::StringProvider(metadata));
-    zimCreator.addMetadata(metakey, std::move(metaProvider), "text/plain");
+    zimCreator.addMetadata(metakey, std::move(metaProvider), std::string{mimeTextPlain});
   }
 
 

--- a/src/zimwriterfs/meson.build
+++ b/src/zimwriterfs/meson.build
@@ -1,6 +1,7 @@
 
 sources = [
   'zimwriterfs.cpp',
+  '../mimetypes.cpp',
   'tools.cpp',
   '../tools.cpp',
   '../metadata.cpp',

--- a/src/zimwriterfs/tools.h
+++ b/src/zimwriterfs/tools.h
@@ -23,6 +23,7 @@
 
 #include <gumbo.h>
 #include <string>
+#include <string_view>
 
 std::string getFileContent(const std::string& path);
 
@@ -30,6 +31,6 @@ std::string extractRedirectUrlFromHtml(const GumboVector* head_children);
 
 std::string generateDate();
 
-std::string getMimeTypeForFile(const std::string& basedir, const std::string& filename);
+std::string getMimeTypeForFile(const std::string& basedir, std::string_view filename);
 
 #endif  // OPENZIM_ZIMWRITERFS_TOOLS_H

--- a/src/zimwriterfs/zimcreatorfs.cpp
+++ b/src/zimwriterfs/zimcreatorfs.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "zimcreatorfs.h"
+#include "../mimetypes.h"
 #include "../tools.h"
 #include "tools.h"
 
@@ -177,11 +178,11 @@ void ZimCreatorFS::addFile(const std::string& path)
   zim::writer::Hints hints;
 
   std::shared_ptr<zim::writer::Item> item;
-  if ( mimetype.find("text/html") != std::string::npos
-    || mimetype.find("text/css") != std::string::npos) {
+  if ( mimetype.find(mimeTextHtml) != std::string::npos
+    || mimetype.find(mimeTextCss) != std::string::npos) {
     auto content = getFileContent(path);
 
-    if (mimetype.find("text/html") != std::string::npos) {
+    if (mimetype.find(mimeTextHtml) != std::string::npos) {
       hints[zim::writer::FRONT_ARTICLE] = 1;
       auto redirectUrl = parseAndAdaptHtml(content, title, url);
       if (!redirectUrl.empty()) {

--- a/test/meson.build
+++ b/test/meson.build
@@ -17,6 +17,7 @@ endif
 
 zimwriter_srcs = [  '../src/zimwriterfs/tools.cpp',
                     '../src/zimwriterfs/zimcreatorfs.cpp',
+                    '../src/mimetypes.cpp',
                     '../src/tools.cpp']
 
 tests_src_map = { 'zimcheck-test' : ['../src/zimcheck/zimcheck.cpp', '../src/zimcheck/checks.cpp',  '../src/zimcheck/json_tools.cpp', '../src/tools.cpp', '../src/metadata.cpp'],


### PR DESCRIPTION
Why: Centralize mimetype definitions so we aren't using raw string literals everywhere for mimetype checks.

Changes:
* mime types moved from `src/zimwriterfs/tools` to `src/mimetypes`
* compile-time known mimetypes are `inline constexpr std::string_view`
  * `inline constexpr` (c++17) will guarantee the respective literals have the same address / are deduplicated across translation units at link time
  * `std::string_view` (c++17) is a lightweight `constexpr` wrapper of a `char*` and `size`, with support for `std::string` interop, but since its `constexpr`, you aren't constructing a bunch of `std::string` objects at runtime to hold copies of the string literal data
* `extMimeTypes` is now a function returning `const&` to the `static std::map` ("static initialization order fiasco")
* `extMimeTypes` map now has a custom comparator for key lookups that will convert inputs to lower case, and otherwise act the same as `std::lexicographical_compare`
  * This allows the extension keys to be deduplicated since now there is no need to have all upper and all lower case entries.
* `zimwriterfs/tools::getMimeTypeForFile`:
  * refactored to use `std::string_view` `extMimeTypes` map entries
  * refactored implementation to be const-correct and exception-free.