### PR TITLE
Remove ubuntu-focal from package build workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -21,7 +21,6 @@ jobs:
 #          - debian-bullseye
           - ubuntu-noble
           - ubuntu-jammy
-          - ubuntu-focal
     steps:
       - uses: actions/checkout@v4
 
@@ -84,14 +83,6 @@ jobs:
         if: matrix.distro == 'ubuntu-jammy'
         name: Build package for ubuntu-jammy
         id: build-ubuntu-jammy
-        with:
-          args: --no-sign
-          ppa: ${{ steps.ppa.outputs.ppa }}
-
-      - uses: legoktm/gh-action-build-deb@ubuntu-focal
-        if: matrix.distro == 'ubuntu-focal'
-        name: Build package for ubuntu-focal
-        id: build-ubuntu-focal
         with:
           args: --no-sign
           ppa: ${{ steps.ppa.outputs.ppa }}


### PR DESCRIPTION
Removed ubuntu-focal from the workflow and its associated build step.