### PR TITLE
zimcheck: fix isOutofBounds bug related to URL queries

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -377,7 +377,8 @@ bool isOutofBounds(const std::string& input, std::string base)
     //count nr of substrings ../
     int nrsteps = 0;
     std::string::size_type pos = 0;
-    while((pos = input.find("../", pos)) != std::string::npos) {
+    std::string::size_type queryPos = input.find("?");
+    while((pos = input.find("../", pos)) != std::string::npos && (pos <= queryPos || queryPos == std::string::npos)) {
         nrsteps++;
         pos += 3;
     }

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -363,12 +363,47 @@ std::vector<html_link> generic_getLinks(const std::string& page)
     return links;
 }
 
+std::string extractPathFromLink(const std::string& link)
+{
+    // Reminder: URL format for hyperrefs is: scheme://user:password@host:port/path?query#fragment
+    // Note: this function assumes that the provided URL is a hyperref and should only be applied on such URLs
+    // strip scheme
+    auto schemeI = link.find("://");
+    if (schemeI != std::string::npos) {
+        schemeI = schemeI + 3;
+    } else {
+        schemeI = 0;
+    }
+    // strip user+password
+    auto authorityEndI = link.find_first_of("/?#", schemeI);
+    auto passwordI = link.find("@", schemeI);
+    if (passwordI != std::string::npos && passwordI < authorityEndI) {
+        passwordI = passwordI + 1;
+    } else {
+        passwordI = schemeI;
+    }
+    // find path
+    auto firstSlashI = link.find("/", passwordI);
+    auto pathEndI = link.find_first_of("?#", passwordI);
+    // a path must start with a / if there is a :// in the URL
+    // if there is no ://, then the path, a path may start without a leading /, but does so immediately
+    std::string path;
+    if (schemeI == 0) {
+        path = link.substr(0, pathEndI);
+    } else {
+        path = link.substr(firstSlashI, pathEndI-firstSlashI);
+    }
+    return path;
+}
+
 bool isOutofBounds(const std::string& input, std::string base)
 {
     if (input.empty()) return false;
 
     if (!base.length() || base.back() != '/')
         base.push_back('/');
+
+    std::string path = extractPathFromLink(input);
 
     int nr = 0;
     if (base.front() != '/')
@@ -377,8 +412,7 @@ bool isOutofBounds(const std::string& input, std::string base)
     //count nr of substrings ../
     int nrsteps = 0;
     std::string::size_type pos = 0;
-    std::string::size_type queryPos = input.find("?");
-    while((pos = input.find("../", pos)) != std::string::npos && (pos <= queryPos || queryPos == std::string::npos)) {
+    while((pos = path.find("../", pos)) != std::string::npos) {
         nrsteps++;
         pos += 3;
     }

--- a/src/tools.h
+++ b/src/tools.h
@@ -194,6 +194,9 @@ void stripTitleInvalidChars(std::string& str);
 //Returns a vector of the links in a particular page. includes links under 'href' and 'src'
 std::vector<html_link> generic_getLinks(const std::string& page);
 
+// extract the path part of a URL
+std::string extractPathFromLink(const std::string& link);
+
 // checks if a relative path is out of bounds (relative to base)
 bool isOutofBounds(const std::string& input, std::string base);
 

--- a/test/tools-test.cpp
+++ b/test/tools-test.cpp
@@ -223,6 +223,19 @@ TEST(tools, uriKind)
     EXPECT_EQ(UriKind::OTHER, uriKind("style.css"));
 }
 
+TEST(tools, extractPathFromLink)
+{
+    EXPECT_EQ("/a/b/c.html", extractPathFromLink("/a/b/c.html"));
+    EXPECT_EQ("a/b/c.html", extractPathFromLink("a/b/c.html"));
+    EXPECT_EQ("/a/b/c.html", extractPathFromLink("https://example.org/a/b/c.html"));
+    EXPECT_EQ("/a/b/c.html", extractPathFromLink("/a/b/c.html?key=value"));
+    EXPECT_EQ("/a/b/c.html", extractPathFromLink("/a/b/c.html#fragment"));
+    EXPECT_EQ("/a/b/c.html", extractPathFromLink("/a/b/c.html?key=value#fragment"));
+    EXPECT_EQ("/a/b/c.html", extractPathFromLink("https://user:password@example.org/a/b/c.html?key=value"));
+    EXPECT_EQ("/a/b/c.html", extractPathFromLink("https://user:password@example.org/a/b/c.html#fragment"));
+    EXPECT_EQ("/a/b/c.html", extractPathFromLink("https://user:password@example.org/a/b/c.html?key=value#fragment"));
+}
+
 TEST(tools, isOutofBounds)
 {
     ASSERT_FALSE(isOutofBounds("", ""));

--- a/test/tools-test.cpp
+++ b/test/tools-test.cpp
@@ -232,6 +232,7 @@ TEST(tools, isOutofBounds)
     ASSERT_FALSE(isOutofBounds("../", "/a"));
     ASSERT_TRUE(isOutofBounds("../../", "/a"));
     ASSERT_TRUE(isOutofBounds("../../../-/s/css_modules/ext.cite.ux-enhancements.css", "A/Blood_/"));
+    ASSERT_FALSE(isOutofBounds("../tool.html?path=../", "dir/"));
 }
 
 TEST(tools, normalize_link)


### PR DESCRIPTION
Greetings,

it's been a while since I've done anything with C++, so feel free to tear the suggested changes of this PR apart.
This is just a simple "I've found a bug and fixed it" PR otherwise.

# Bug report (fix follows in the next section)

**Observed Behavior:**

I've recently found `zimcheck` failing with the error message indicating that an URL was out of bounds despite being valid. 
Let's assume the following ZIM structure:

```
ZIM_ROOT (/)
 - tools/
    - tool.html
 - dir/
    - subdir/
      - index.html
      - file.html
```

The URL was something along the lines of `../../tools/tool.html?path=../dir/subdir/file.html` with the base directory being `/dir/subdir/index.html`. Now, this URL should resolve to `/tools/tool.html?path=../dir/subdir/file.html`. Entirely valid, yet `zimcheck` fails due to wrongly identifying the above link as out of bounds (meaining that it reaches beyond the ZIM root directory).

Here's a minimal example of the failing code:

```c++
int main() {
    std::string inp = "../../tool.html?path=../dir/subdir/file.html";
    std::string path = "dir/subdir/index.html";
    auto baseUrl = path;
    auto pos = baseUrl.find_last_of('/');
    baseUrl.resize( pos==baseUrl.npos ? 0 : pos );

    cout << "path: " << path << "\n";
    cout << "base: " << baseUrl << "\n";
    cout << "inp:  " << inp << "\n";

    if (isOutofBounds(inp, baseUrl)) {
        cout << "OOB: true\n";
    } else {
        cout << "OOB: false\n";
    }
    return 0;
}
```

**Expected behavior:**

As you can probably guess from the previous subsection, the expected behavior is that the link shouldn't be identified as an out of bounds link. Consequently, `zimcheck` should not fail the zim.

# The fix

The problem lies in the `isOutofBounds` function, which doesn't properly parse the HTML links. Rather, it interprets the links as filesystem paths. Which is probably sort-of valid for some file types, but for HTML files the links must be interpreted as hyperlinks. The `isOutofBounds` function is rather crude in that it only compares to number of occourences of `/` and ` ../` against each other rather than actualyl understanding how a hyperlink URL may be structured.

~The bug in this PR can be fixed by limiting the range in which the `../` occurences are counted by the first occurence of `?`.~ The bug in this PR can be fixed by properly extracting the path component of the URL and only checking isOutOfBounds on that part.


~**Important note::** this fix is just as "crude" as the original function. It doesn't really resolve the underlying issue - that being the lack of understanding of how a URL works - and thus doesn't fix like a dozen other potential issues I can think of. For example, should a URL specify a fragment containing `../`, this same issue may occur.~

# Other stuff

This PR contains a new function `extractPathFromLink`, which is used to get the path component of a http URL, as well as tests for both this new function and the bug described in this issue.