### PR TITLE
Using windows-2025 runner for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
           meson test --verbose
 
   Windows:
-    runs-on: windows-2022
+    runs-on: windows-2025
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
We just have moved on kiwix-build side, see https://github.com/kiwix/kiwix-build/pull/838