### PR TITLE
fix: modify getTextLength to use BreakIterator for grapheme count

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -25,6 +25,7 @@ with_xapian_support = compiler.has_header_symbol(
 find_library_in_compiler = meson.version().version_compare('>=0.31.0')
 rt_dep = dependency('rt', required:false)
 docopt_dep = dependency('docopt', static:static_linkage)
+icu_uc_dep = dependency('icu-uc', static:static_linkage)
 icu_dep = dependency('icu-i18n', static:static_linkage)
 
 with_writer = host_machine.system() != 'windows'

--- a/src/meson.build
+++ b/src/meson.build
@@ -15,15 +15,15 @@ if target_machine.system() != 'windows'
 endif
 
 executable('zimdump', 'zimdump.cpp', 'tools.cpp',
-  dependencies: [libzim_dep, docopt_dep],
+  dependencies: [libzim_dep, docopt_dep, icu_uc_dep, icu_dep],
   install: true)
 
 executable('zimdiff', ['zimdiff.cpp', 'tools.cpp'],
-  dependencies: libzim_dep,
+  dependencies: [libzim_dep, icu_uc_dep, icu_dep],
   install: true)
 
 executable('zimpatch', ['zimpatch.cpp', 'tools.cpp'],
-  dependencies: libzim_dep,
+  dependencies: [libzim_dep, icu_uc_dep, icu_dep],
   install: true)
 
 executable('zimsplit', 'zimsplit.cpp',
@@ -31,7 +31,7 @@ executable('zimsplit', 'zimsplit.cpp',
   install: true)
 
 executable('zimrecreate', ['zimrecreate.cpp', 'tools.cpp'],
-  dependencies: libzim_dep,
+  dependencies: [libzim_dep, icu_uc_dep, icu_dep],
   install: true)
 
 subdir('zimcheck')

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -18,10 +18,11 @@
  */
 
 #include "metadata.h"
+#include "tools.h"
 
 #include <sstream>
 #include <regex>
-#include <unicode/unistr.h>
+
 
 #include <cctype>
 #include <iomanip>
@@ -45,25 +46,6 @@ bool searchRegex(const std::string& regexStr, const std::string& text)
 {
   const std::regex regex(regexStr);
   return std::regex_search(text.begin(), text.end(), regex);
-}
-
-size_t getTextLength(const std::string& utf8EncodedString)
-{
-  // For some unknown reason implicite convertion from std::string to icu::StringPiece
-  // is broken on Windows.
-  // Constructors are definde in stringpiece.h as
-  // ```
-  // StringPiece(const std::string& str)
-  //  : ptr_(str.data()), length_(static_cast<int32_t>(str.size())) { }
-  // StringPiece(const char* offset, int32_t len) : ptr_(offset), length_(len) { }
-  // ```
-  // However using the first constructor ends with a corrupted StringPiece (wrong ptr)
-  // and using second one works. Don't ask me why
-  // This is broken
-  // icu::StringPiece stringPiece(utf8EncodedString);
-  // This is not
-  icu::StringPiece stringPiece(utf8EncodedString.data(), static_cast<int32_t>(utf8EncodedString.size()));
-  return icu::UnicodeString::fromUTF8(stringPiece).length();
 }
 
 class MetadataComplexCheckBase

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -33,6 +33,8 @@
 #include <algorithm>
 #include <regex>
 #include <array>
+#include <unicode/brkiter.h>
+#include <unicode/utypes.h>
 #include <unicode/unistr.h>
 
 #ifdef _WIN32
@@ -680,6 +682,23 @@ size_t getTextLength(const std::string& utf8EncodedString)
   // This is broken
   // icu::StringPiece stringPiece(utf8EncodedString);
   // This is not
-  icu::StringPiece stringPiece(utf8EncodedString.data(), static_cast<int32_t>(utf8EncodedString.size()));
-  return icu::UnicodeString::fromUTF8(stringPiece).length();
+  icu::StringPiece stringPiece(utf8EncodedString.data(),
+                               static_cast<int32_t>(utf8EncodedString.size()));
+  icu::UnicodeString ustr = icu::UnicodeString::fromUTF8(stringPiece);
+
+  UErrorCode status = U_ZERO_ERROR;
+  std::unique_ptr<icu::BreakIterator> bi(
+      icu::BreakIterator::createCharacterInstance(icu::Locale::getRoot(), status));
+
+  if (!U_SUCCESS(status)) {
+    return ustr.length();  // Fallback to codepoint count
+  }
+
+  bi->setText(ustr);
+
+  size_t count = 0;
+  while (bi->next() != icu::BreakIterator::DONE) {
+    ++count;
+  }
+  return count;
 }

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -33,6 +33,7 @@
 #include <algorithm>
 #include <regex>
 #include <array>
+#include <unicode/unistr.h>
 
 #ifdef _WIN32
 #define SEPARATOR "\\"
@@ -662,4 +663,23 @@ std::string httpRedirectHtml(const std::string& redirectUrl)
 bool guess_is_front_article(const std::string& mimetype) {
   return ( mimetype.find("text/html") == 0
         && mimetype.find("raw=true") == std::string::npos);
+}
+
+size_t getTextLength(const std::string& utf8EncodedString)
+{
+  // For some unknown reason implicite convertion from std::string to icu::StringPiece
+  // is broken on Windows.
+  // Constructors are definde in stringpiece.h as
+  // ```
+  // StringPiece(const std::string& str)
+  //  : ptr_(str.data()), length_(static_cast<int32_t>(str.size())) { }
+  // StringPiece(const char* offset, int32_t len) : ptr_(offset), length_(len) { }
+  // ```
+  // However using the first constructor ends with a corrupted StringPiece (wrong ptr)
+  // and using second one works. Don't ask me why
+  // This is broken
+  // icu::StringPiece stringPiece(utf8EncodedString);
+  // This is not
+  icu::StringPiece stringPiece(utf8EncodedString.data(), static_cast<int32_t>(utf8EncodedString.size()));
+  return icu::UnicodeString::fromUTF8(stringPiece).length();
 }

--- a/src/tools.h
+++ b/src/tools.h
@@ -271,6 +271,7 @@ std::string httpRedirectHtml(const std::string& redirectUrl);
 
 std::string asciitolower(std::string s);
 
+// Return the count of graphemes in the provided text string
 size_t getTextLength(const std::string& utf8EncodedString);
 
 #endif  // OPENZIM_TOOLS_H

--- a/src/tools.h
+++ b/src/tools.h
@@ -271,4 +271,6 @@ std::string httpRedirectHtml(const std::string& redirectUrl);
 
 std::string asciitolower(std::string s);
 
+size_t getTextLength(const std::string& utf8EncodedString);
+
 #endif  // OPENZIM_TOOLS_H

--- a/src/zimcheck/meson.build
+++ b/src/zimcheck/meson.build
@@ -8,7 +8,7 @@ endif
 
 inc = include_directories(extra_include)
 
-zimcheck_deps = [libzim_dep, icu_dep, docopt_dep]
+zimcheck_deps = [libzim_dep, icu_uc_dep, icu_dep, docopt_dep]
 
 # C++ std::thread is implemented using pthread on Linux by GCC, and on FreeBSD
 # for both GCC and LLVM.

--- a/src/zimwriterfs/meson.build
+++ b/src/zimwriterfs/meson.build
@@ -7,7 +7,7 @@ sources = [
   'zimcreatorfs.cpp'
 ]
 
-deps = [thread_dep, libzim_dep, zlib_dep, gumbo_dep, magic_dep, icu_dep]
+deps = [thread_dep, libzim_dep, zlib_dep, gumbo_dep, magic_dep, icu_uc_dep, icu_dep]
 
 zimwriterfs = executable('zimwriterfs',
                          sources,

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,7 +1,7 @@
 gtest_dep = dependency('gtest', main:true, fallback:['gtest', 'gtest_main_dep'], required:false)
 
 
-test_deps = [gtest_dep, libzim_dep, icu_dep, docopt_dep]
+test_deps = [gtest_dep, libzim_dep, icu_uc_dep, icu_dep, docopt_dep]
 tests = [
     'metadata-test',
     'zimcheck-test'

--- a/test/meson.build
+++ b/test/meson.build
@@ -21,7 +21,7 @@ zimwriter_srcs = [  '../src/zimwriterfs/tools.cpp',
 
 tests_src_map = { 'zimcheck-test' : ['../src/zimcheck/zimcheck.cpp', '../src/zimcheck/checks.cpp',  '../src/zimcheck/json_tools.cpp', '../src/tools.cpp', '../src/metadata.cpp'],
                   'tools-test' : zimwriter_srcs,
-                  'metadata-test' : ['../src/metadata.cpp'],
+                  'metadata-test' : ['../src/metadata.cpp', '../src/tools.cpp'],
                   'zimwriterfs-zimcreatorfs' : zimwriter_srcs }
 
 if gtest_dep.found() and not meson.is_cross_build()

--- a/test/tools-test.cpp
+++ b/test/tools-test.cpp
@@ -700,3 +700,26 @@ TEST(CommonTools, AsciiToLower) {
     EXPECT_EQ(asciitolower("ÄBÇ123!"), "ÄbÇ123!");
     EXPECT_EQ(asciitolower("lower"), "lower");
 }
+
+TEST(CommonTools, getTextLength)
+{
+  // Basic ASCII
+  EXPECT_EQ(getTextLength(""), 0u);
+  EXPECT_EQ(getTextLength("hello"), 5u);
+
+  // Multi-byte UTF-8 (1 codepoint each)
+  EXPECT_EQ(getTextLength("café"), 4u);
+  EXPECT_EQ(getTextLength("日本語"), 3u);
+
+  // BUG TEST: Hindi "में" = 1 grapheme, 3 codepoints
+  EXPECT_EQ(getTextLength("में"), 1u);
+
+  // ZWJ emoji: 👨‍👩‍👧 = 1 grapheme, 5 codepoints
+  EXPECT_EQ(getTextLength("\U0001F468\u200D\U0001F469\u200D\U0001F467"), 1u);
+
+  // Emoji + skin tone: 👋🏽 = 1 grapheme, 2 codepoints
+  EXPECT_EQ(getTextLength("\U0001F44B\U0001F3FD"), 1u);
+
+  // Mixed: "café में" = 6 graphemes
+  EXPECT_EQ(getTextLength("café में"), 6u);
+}


### PR DESCRIPTION
Fixes #498

Used ICU's BreakIterator, took the definition code from their documentation + added a status check as well. 
Please suggest changes if needed, considering this is my first time working with this. 