### PR TITLE
More responsible (though still custom) link parsing from HTML

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -349,7 +349,28 @@ std::vector<html_link> generic_getLinks(const std::string& page)
     std::vector<html_link> links;
     std::string attr;
 
+    // The difference of the counts of the '<' and '>' characters preceding
+    // the current position. In a valid HTML without comments it should only
+    // take values 0 or 1.
+    int ltgtBalance = 0;
+
     while (*p) {
+        if ( *p == '<' ) {
+          ++ltgtBalance;
+          ++p;
+          continue;
+        }
+        if ( *p == '>' ) {
+          --ltgtBalance;
+          ++p;
+          continue;
+        }
+
+        if ( ltgtBalance != 1 ) {
+          ++p;
+          continue;
+        }
+
         if (strncmp(p, " href", 5) == 0) {
             attr = "href";
             p += 5;

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -356,6 +356,12 @@ const char* strSkipTillRightAfter(const char* p, const char* s)
     return p;
 }
 
+bool isScriptTag(const char* p)
+{
+  return strncmp(p, "<script", 7) == 0
+      && (p[7] == '>' || p[7] == ' ');
+}
+
 } // unnamed namespace
 
 std::vector<html_link> generic_getLinks(const std::string& page)
@@ -374,6 +380,10 @@ std::vector<html_link> generic_getLinks(const std::string& page)
         if ( *p == '<' ) {
           if (strncmp(p, "<!--", 4) == 0) {
             p = strSkipTillRightAfter(p, "-->");
+            continue;
+          }
+          if (isScriptTag(p)) {
+            p = strSkipTillRightAfter(p, "</script>");
             continue;
           }
 

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -342,6 +342,22 @@ std::string decodeHtmlEntities(const std::string& str)
   return result;
 }
 
+namespace
+{
+
+const char* strSkipTillRightAfter(const char* p, const char* s)
+{
+    const int slen = strlen(s);
+    for ( ; *p ; ++p) {
+        if ( strncmp(p, s, slen) == 0 ) {
+            return p + slen;
+        }
+    }
+    return p;
+}
+
+} // unnamed namespace
+
 std::vector<html_link> generic_getLinks(const std::string& page)
 {
     const char* p = page.c_str();
@@ -356,6 +372,11 @@ std::vector<html_link> generic_getLinks(const std::string& page)
 
     while (*p) {
         if ( *p == '<' ) {
+          if (strncmp(p, "<!--", 4) == 0) {
+            p = strSkipTillRightAfter(p, "-->");
+            continue;
+          }
+
           ++ltgtBalance;
           ++p;
           continue;

--- a/test/tools-test.cpp
+++ b/test/tools-test.cpp
@@ -387,8 +387,6 @@ TEST(tools, getLinks)
       "{ src, https://example.com/getlogo?w=640&h=480 }"
     );
 
-    // Known issue - HTML is not parsed and therefore false links
-    //               may be returned
     EXPECT_LINKS(
       R"(
 <html>
@@ -414,10 +412,6 @@ TEST(tools, getLinks)
       "{ src, /css/stylesheet.css }"                      "\n"
       "{ href, /favicon.ico }"                            "\n"
       "{ src, ../img/welcome.png }"                       "\n"
-      "{ href, commented_out_link.htm }"                  "\n"
-      "{ src, commented_out_image.png }"                  "\n"
-      "{ href, not_a_link_in_example_code_block.htm }"    "\n"
-      "{ src, not_a_link_in_example_code_block.png }"     "\n"
       "{ href, https://kiwix.org }"
     );
 

--- a/test/tools-test.cpp
+++ b/test/tools-test.cpp
@@ -342,7 +342,7 @@ std::string links2Str(const std::vector<html_link>& links)
 }
 
 #define EXPECT_LINKS(html, expectedStr) \
-        ASSERT_EQ(links2Str(generic_getLinks(html)), expectedStr)
+        EXPECT_EQ(links2Str(generic_getLinks(html)), expectedStr)
 
 TEST(tools, getLinks)
 {
@@ -414,6 +414,43 @@ TEST(tools, getLinks)
       "{ src, ../img/welcome.png }"                       "\n"
       "{ href, https://kiwix.org }"
     );
+
+    EXPECT_LINKS(
+      R"(<div>
+          <!--
+            < a href="pseudolink_in_a_comment_with_an_unmatched_lt_char.htm"
+          -->
+          <a href="real_link.html"></a>
+      </div>)",
+
+      // links
+      "{ href, real_link.html }"
+    );
+
+    EXPECT_LINKS(
+      R"(<div>
+          <!--
+            > a href="pseudolink_in_a_comment_with_an_unmatched_gt_char.htm"
+          -->
+          <a href="real_link.html"></a>
+      </div>)",
+
+      // links
+      "{ href, real_link.html }"
+    );
+
+    EXPECT_LINKS(
+      R"(<div>
+          <!--
+            > <a href="pseudolink_in_a_comment_with_gt_before_lt.htm"
+          -->
+          <a href="real_link.html"></a>
+      </div>)",
+
+      // links
+      "{ href, real_link.html }"
+    );
+
 
     // Despite HTML not being properly parsed, not every href or src followed
     // by an equality sign (with optional whitespace in between) results in a

--- a/test/tools-test.cpp
+++ b/test/tools-test.cpp
@@ -451,6 +451,33 @@ TEST(tools, getLinks)
       "{ href, real_link.html }"
     );
 
+    EXPECT_LINKS(
+      R"(<script>
+          console.log("<a href='pseudolink_inside_a_script_tag1'>");
+         </script>
+         <script id="whatever">
+          console.log("<a href='pseudolink_inside_a_script_tag2'>");
+         </script>
+         <a href="real_link.html"></a>
+      )",
+
+      // links
+      "{ href, real_link.html }"
+    );
+
+    EXPECT_LINKS(
+      R"(<script>
+          if ( 1 > 0 ) console.log("unmatched > inside a script tag");
+         </script>
+         <script id="whatever">
+          if ( 1 > 0 ) console.log("unmatched > inside a script tag");
+         </script>
+         <a href="real_link.html"></a>
+      )",
+
+      // links
+      "{ href, real_link.html }"
+    );
 
     // Despite HTML not being properly parsed, not every href or src followed
     // by an equality sign (with optional whitespace in between) results in a


### PR DESCRIPTION
Should fix #149, #485 & #508 

This PR counts the `<` and `>` characters while parsing the HTML input and considers only those occurrences of `href` and `src` strings that qualify as an attribute for an XML tag.

HTML comments and `<script>` elements are handled. The only assumption is that a `<script>` tag doesn't contain whitespace between `<` and `script` (as in `< script >` ) but that can be fixed easily if needed.