### PR TITLE
Classify arbitrary URI schemes as external

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -569,6 +569,16 @@ std::string resolveLinkTarget(std::string url, const std::string& zimPath) {
 namespace
 {
 
+bool isAsciiAlpha(const char c)
+{
+    return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+}
+
+bool isAsciiAlphaNumeric(const char c)
+{
+    return isAsciiAlpha(c) || (c >= '0' && c <= '9');
+}
+
 UriKind specialUriSchemeKind(const std::string& s)
 {
     static const std::map<std::string, UriKind> uriSchemes = {
@@ -623,7 +633,7 @@ static bool isReservedUrlChar(const char c)
 
 bool needsEscape(const char c, const bool encodeReserved)
 {
-  if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9'))
+  if (isAsciiAlphaNumeric(c))
     return false;
 
   if (isReservedUrlChar(c))

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -579,6 +579,18 @@ bool isAsciiAlphaNumeric(const char c)
     return isAsciiAlpha(c) || (c >= '0' && c <= '9');
 }
 
+bool isValidUriScheme(const std::string& scheme)
+{
+    if (scheme.empty() || !isAsciiAlpha(scheme.front())) {
+        return false;
+    }
+
+    return std::all_of(
+        scheme.begin() + 1,
+        scheme.end(),
+        [](const char c) { return isAsciiAlphaNumeric(c) || c == '+' || c == '-' || c == '.'; });
+}
+
 UriKind specialUriSchemeKind(const std::string& s)
 {
     static const std::map<std::string, UriKind> uriSchemes = {
@@ -594,7 +606,7 @@ UriKind specialUriSchemeKind(const std::string& s)
     };
 
     const auto it = uriSchemes.find(s);
-    return it != uriSchemes.end() ? it->second : UriKind::OTHER;
+    return it != uriSchemes.end() ? it->second : UriKind::GENERIC_URI;
 }
 
 
@@ -610,12 +622,16 @@ UriKind html_link::detectUriKind(const std::string& input_string)
             return UriKind::OTHER;
     }
 
+    const std::string raw_scheme = input_string.substr(0, k);
+    if (!isValidUriScheme(raw_scheme)) {
+        return UriKind::OTHER;
+    }
     if ( k + 2 < input_string.size()
          && input_string[k+1] == '/'
          && input_string[k+2] == '/' )
         return UriKind::GENERIC_URI;
 
-    const std::string scheme = asciitolower(input_string.substr(0, k));
+    const std::string scheme = asciitolower(raw_scheme);
     return specialUriSchemeKind(scheme);
 }
 

--- a/src/tools.h
+++ b/src/tools.h
@@ -71,7 +71,7 @@ enum class UriKind : int
     NEWS,           // news:comp.os.linux.announce
     URN,            // urn:nbn:de:bsz:24-digibib-bsz3530416370
 
-    GENERIC_URI,    // Generic URI with scheme and authority: <scheme>://.....
+    GENERIC_URI,    // Generic URI with a scheme: <scheme>:... or <scheme>://.....
     PROTOCOL_RELATIVE, // Protocol-relative URL: //<host>/<path>/<to>/<resource>
 
     OTHER           // not a valid URI (though it can be a valid relative

--- a/test/tools-test.cpp
+++ b/test/tools-test.cpp
@@ -202,17 +202,21 @@ TEST(tools, uriKind)
     EXPECT_EQ(UriKind::DATA, uriKind("data:text/plain;charset=UTF-8,data"));
     EXPECT_EQ(UriKind::DATA, uriKind("DATA:text/plain;charset=UTF-8,data"));
 
-    EXPECT_EQ(UriKind::OTHER, uriKind("http:example.com"));
-    EXPECT_EQ(UriKind::OTHER, uriKind("http:/example.com"));
+    EXPECT_EQ(UriKind::GENERIC_URI, uriKind("http:example.com"));
+    EXPECT_EQ(UriKind::GENERIC_URI, uriKind("http:/example.com"));
     EXPECT_EQ(UriKind::OTHER, uriKind("git@github.com:openzim/zim-tools.git"));
     EXPECT_EQ(UriKind::OTHER, uriKind("/redirect?url=http://example.com"));
     EXPECT_EQ(UriKind::OTHER, uriKind("redirect?url=http://example.com"));
     EXPECT_EQ(UriKind::OTHER, uriKind("auth.php#returnurl=https://example.com"));
     EXPECT_EQ(UriKind::OTHER, uriKind("/api/v1/http://example.com"));
     EXPECT_EQ(UriKind::OTHER, uriKind("img/file:///etc/passwd"));
-    EXPECT_EQ(UriKind::OTHER, uriKind("ftp:/download.kiwix.org/zim/"));
-    EXPECT_EQ(UriKind::OTHER, uriKind("sendmailto:someone@example.com"));
-    EXPECT_EQ(UriKind::OTHER, uriKind("intel:+0123456789"));
+    EXPECT_EQ(UriKind::GENERIC_URI, uriKind("ftp:/download.kiwix.org/zim/"));
+    EXPECT_EQ(UriKind::GENERIC_URI, uriKind("sendmailto:someone@example.com"));
+    EXPECT_EQ(UriKind::GENERIC_URI, uriKind("intel:+0123456789"));
+    EXPECT_EQ(UriKind::GENERIC_URI, uriKind("custom-scheme:opaque-value"));
+    EXPECT_EQ(UriKind::GENERIC_URI, uriKind("My2+scheme.value:opaque-value"));
+    EXPECT_EQ(UriKind::OTHER, uriKind("\xC3\xA9scheme:value"));
+    EXPECT_EQ(UriKind::OTHER, uriKind("custom\xC3\xA9:value"));
     EXPECT_EQ(UriKind::OTHER, uriKind("showlocation.cgi?geo:12.34,56.78"));
     EXPECT_EQ(UriKind::OTHER, uriKind("/xyz/javascript:console.log('hello, world!')"));
 
@@ -221,6 +225,42 @@ TEST(tools, uriKind)
     EXPECT_EQ(UriKind::OTHER, uriKind("../img/logo.png"));
     EXPECT_EQ(UriKind::OTHER, uriKind("style.css"));
 }
+
+#define EXPECT_INTERNAL_LINK(url) \
+    do { \
+        EXPECT_FALSE(html_link(html_link::HREF, (url)).isExternalUrl()); \
+        EXPECT_FALSE(html_link(html_link::SRC, (url)).isExternalUrl()); \
+    } while (false)
+
+#define EXPECT_EXTERNAL_LINK(url) \
+    do { \
+        EXPECT_TRUE(html_link(html_link::HREF, (url)).isExternalUrl()); \
+        EXPECT_TRUE(html_link(html_link::SRC, (url)).isExternalUrl()); \
+    } while (false)
+
+TEST(tools, linkClassification)
+{
+    EXPECT_INTERNAL_LINK("data:text/plain,payload");
+    EXPECT_INTERNAL_LINK("../css/dark.css");
+    EXPECT_INTERNAL_LINK("/js/light.js");
+    EXPECT_INTERNAL_LINK("goodbye");
+    EXPECT_INTERNAL_LINK("git@github.com:openzim/zim-tools.git");
+    EXPECT_INTERNAL_LINK("/redirect?url=http://example.com");
+    EXPECT_INTERNAL_LINK("redirect?url=http://example.com");
+    EXPECT_INTERNAL_LINK("?page=2");
+    EXPECT_INTERNAL_LINK("#footnote1e100");
+    EXPECT_INTERNAL_LINK("auth.php#returnurl=https://example.com");
+    EXPECT_INTERNAL_LINK("/api/v1/http://example.com");
+    EXPECT_INTERNAL_LINK("img/file:///etc/passwd");
+
+    EXPECT_EXTERNAL_LINK("custom-scheme:opaque-value");
+    EXPECT_EXTERNAL_LINK("http://example.com");
+    EXPECT_EXTERNAL_LINK("mailto:someone@example.com");
+    EXPECT_EXTERNAL_LINK("//example.com/welcome");
+}
+
+#undef EXPECT_INTERNAL_LINK
+#undef EXPECT_EXTERNAL_LINK
 
 TEST(tools, resolveLinkTarget)
 {


### PR DESCRIPTION
## Summary

- recognize valid URI schemes even when no authority component is present
- keep `data:` URIs exempt from external-link reporting
- preserve relative-path handling and add focused coverage for valid and invalid scheme forms

Closes #517

## Validation

- `git diff --check`
- Added coverage for empty, non-letter, and invalid-character scheme prefixes
- Native Meson, Ninja, compiler, and pkg-config tools are not installed in this Windows checkout, so the native test binary could not be built locally
- The repository CI provides the native build and test validation

## Scope

This change only adjusts URI classification and its focused tests. It does not change relative-path resolution or the handling of `data:` URIs.
