### PR TITLE
Treat unknown URI schemes as external

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -576,6 +576,21 @@ UriKind specialUriSchemeKind(const std::string& s)
     return it != uriSchemes.end() ? it->second : UriKind::OTHER;
 }
 
+bool isValidUriScheme(const std::string& s)
+{
+    const auto isAlpha = [](const char c) {
+        return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z');
+    };
+
+    if (s.empty() || !isAlpha(s.front()))
+        return false;
+
+    return std::all_of(s.begin() + 1, s.end(), [&isAlpha](const char c) {
+        return isAlpha(c) || ('0' <= c && c <= '9')
+               || c == '+' || c == '-' || c == '.';
+    });
+}
+
 
 } // unnamed namespace
 
@@ -589,13 +604,17 @@ UriKind html_link::detectUriKind(const std::string& input_string)
             return UriKind::OTHER;
     }
 
+    const std::string scheme = input_string.substr(0, k);
+    if ( !isValidUriScheme(scheme) )
+        return UriKind::OTHER;
+
     if ( k + 2 < input_string.size()
          && input_string[k+1] == '/'
          && input_string[k+2] == '/' )
         return UriKind::GENERIC_URI;
 
-    const std::string scheme = asciitolower(input_string.substr(0, k));
-    return specialUriSchemeKind(scheme);
+    const UriKind uriKind = specialUriSchemeKind(asciitolower(scheme));
+    return uriKind == UriKind::OTHER ? UriKind::GENERIC_URI : uriKind;
 }
 
 namespace

--- a/src/tools.h
+++ b/src/tools.h
@@ -71,7 +71,7 @@ enum class UriKind : int
     NEWS,           // news:comp.os.linux.announce
     URN,            // urn:nbn:de:bsz:24-digibib-bsz3530416370
 
-    GENERIC_URI,    // Generic URI with scheme and authority: <scheme>://.....
+    GENERIC_URI,    // Generic URI with a scheme: <scheme>:.....
     PROTOCOL_RELATIVE, // Protocol-relative URL: //<host>/<path>/<to>/<resource>
 
     OTHER           // not a valid URI (though it can be a valid relative

--- a/test/tools-test.cpp
+++ b/test/tools-test.cpp
@@ -202,17 +202,25 @@ TEST(tools, uriKind)
     EXPECT_EQ(UriKind::DATA, uriKind("data:text/plain;charset=UTF-8,data"));
     EXPECT_EQ(UriKind::DATA, uriKind("DATA:text/plain;charset=UTF-8,data"));
 
-    EXPECT_EQ(UriKind::OTHER, uriKind("http:example.com"));
-    EXPECT_EQ(UriKind::OTHER, uriKind("http:/example.com"));
+    EXPECT_EQ(UriKind::GENERIC_URI, uriKind("http:example.com"));
+    EXPECT_EQ(UriKind::GENERIC_URI, uriKind("http:/example.com"));
+    EXPECT_EQ(UriKind::GENERIC_URI, uriKind("ftp:/download.kiwix.org/zim/"));
+    EXPECT_EQ(UriKind::GENERIC_URI, uriKind("custom:path"));
+    EXPECT_EQ(UriKind::GENERIC_URI, uriKind("CUSTOM:path"));
+    EXPECT_EQ(UriKind::GENERIC_URI, uriKind("web+demo:path"));
+    EXPECT_EQ(UriKind::GENERIC_URI, uriKind("web-demo:path"));
+    EXPECT_EQ(UriKind::GENERIC_URI, uriKind("web.demo:path"));
+    EXPECT_EQ(UriKind::GENERIC_URI, uriKind("sendmailto:someone@example.com"));
+    EXPECT_EQ(UriKind::GENERIC_URI, uriKind("intel:+0123456789"));
+
     EXPECT_EQ(UriKind::OTHER, uriKind("git@github.com:openzim/zim-tools.git"));
+    EXPECT_EQ(UriKind::OTHER, uriKind("1custom:path"));
+    EXPECT_EQ(UriKind::OTHER, uriKind("custom_scheme:path"));
     EXPECT_EQ(UriKind::OTHER, uriKind("/redirect?url=http://example.com"));
     EXPECT_EQ(UriKind::OTHER, uriKind("redirect?url=http://example.com"));
     EXPECT_EQ(UriKind::OTHER, uriKind("auth.php#returnurl=https://example.com"));
     EXPECT_EQ(UriKind::OTHER, uriKind("/api/v1/http://example.com"));
     EXPECT_EQ(UriKind::OTHER, uriKind("img/file:///etc/passwd"));
-    EXPECT_EQ(UriKind::OTHER, uriKind("ftp:/download.kiwix.org/zim/"));
-    EXPECT_EQ(UriKind::OTHER, uriKind("sendmailto:someone@example.com"));
-    EXPECT_EQ(UriKind::OTHER, uriKind("intel:+0123456789"));
     EXPECT_EQ(UriKind::OTHER, uriKind("showlocation.cgi?geo:12.34,56.78"));
     EXPECT_EQ(UriKind::OTHER, uriKind("/xyz/javascript:console.log('hello, world!')"));
 


### PR DESCRIPTION
## Summary

- validate URI schemes using the RFC 3986 scheme syntax
- classify unknown but valid schemes as generic external URIs
- preserve special handling for known schemes such as `data:`
- add regression coverage for valid and invalid custom schemes

## Why

`detectUriKind()` previously treated a URI as external only when it used a known scheme or contained an authority component (`://`). Valid URIs with an unknown scheme and no authority component were therefore treated as internal links by `zimcheck`.

This change makes any syntactically valid explicit scheme external while keeping relative links and malformed schemes internal.

## Validation

- `git diff --check`
- focused regression vectors validated locally
- full C++ build and test suite deferred to GitHub Actions because the local environment does not contain the project's native build dependencies

Fixes #517
