### PR TITLE
Fixed zimsplit's --size option

### DIFF
--- a/src/zimsplit.cpp
+++ b/src/zimsplit.cpp
@@ -92,7 +92,7 @@ class ZimSplitter
 
     void close_file() {
         if (currentPartSize > maxPartSize) {
-           std::cout << "WARNING: Part " << part_name << " is bigger that max part size."
+           std::cout << "WARNING: Part " << part_name << " is bigger than max part size."
             << " (" << currentPartSize << ">" << maxPartSize << ")" << std::endl;
         }
         ofile.close();

--- a/src/zimsplit.cpp
+++ b/src/zimsplit.cpp
@@ -30,7 +30,18 @@
 
 #define BUFFER_SIZE 4096
 
-#define DEFAULT_PART_SIZE 2147483648
+const zim::size_type DEFAULT_PART_SIZE = 2147483648;
+
+uint64_t asUint64(const std::string& str) {
+    std::istringstream iss(str);
+    int64_t ret;
+    iss >> ret;
+    if(iss.fail() || !iss.eof() || ret < 0) {
+        const auto msg = "invalid uint64_t value: " + str;
+        throw std::invalid_argument(msg);
+    }
+    return ret;
+}
 
 class ZimSplitter
 {
@@ -191,7 +202,7 @@ int main(int argc, char* argv[])
 
     zim::size_type size = DEFAULT_PART_SIZE;
     if (args["--size"])
-        size = args["--size"].asLong();
+        size = asUint64(args["--size"].asString());
 
     // initalize app
     ZimSplitter app(args["<file>"].asString(), prefix, size);


### PR DESCRIPTION
Fixes #434 

The value of the `--size` option is now parsed as a 64-bit value (regardless of the bit-width of the `long int` type of the compiler used). This change also fixes a bug where negative values for the `--size` option were not rejected but were silently converted to a large positive value.  

Since the bug was about parsing of a numeric value exceeding the 32-bit range I only tested that the new parsing code works (didn't run `zimsplit` on a huge ZIM file using chunk size in excess of 2GiB).