### PR TITLE
Fixed generic_getLinks() for <script src="...">

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -381,7 +381,6 @@ std::vector<html_link> generic_getLinks(const std::string& page)
 {
     const char* p = page.c_str();
     std::vector<html_link> links;
-    std::string attr;
 
     // The difference of the counts of the '<' and '>' characters preceding
     // the current position. In a valid HTML without comments it should only
@@ -419,11 +418,12 @@ std::vector<html_link> generic_getLinks(const std::string& page)
           continue;
         }
 
+        html_link::AttributeKind attr;
         if (strncmp(p, " href", 5) == 0) {
-            attr = "href";
+            attr = html_link::HREF;
             p += 5;
         } else if (strncmp(p, " src", 4) == 0) {
-            attr = "src";
+            attr = html_link::SRC;
             p += 4;
         } else {
             p += 1;

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -359,12 +359,27 @@ const char* strSkipTillRightAfter(const char* p, const char* s)
     return p;
 }
 
+inline const char* skipWhitespace(const char* p)
+{
+    while (*p == ' ')
+        ++p;
+
+    return p;
+}
+
+std::string getStringBeforeNext(const char* p, char c) {
+    const char* const s = p;
+    // XXX: don't run beyond end of string
+    while(*p != c)
+        p++;
+    return std::string(s, p);
+}
+
 } // unnamed namespace
 
 std::vector<html_link> generic_getLinks(const std::string& page)
 {
     const char* p = page.c_str();
-    const char* linkStart;
     std::vector<html_link> links;
     std::string attr;
 
@@ -415,23 +430,17 @@ std::vector<html_link> generic_getLinks(const std::string& page)
             continue;
         }
 
-        while (*p == ' ')
-            p += 1 ;
+        p = skipWhitespace(p);
         if (*(p++) != '=')
             continue;
-        while (*p == ' ')
-            p += 1;
-        char delimiter = *p++;
+        p = skipWhitespace(p);
+        const char delimiter = *p++;
         if (delimiter != '\'' && delimiter != '"')
             continue;
 
-        linkStart = p;
-        // [TODO] Handle escape char
-        while(*p != delimiter)
-            p++;
-        const std::string link(linkStart, p);
+        const auto link = getStringBeforeNext(p, delimiter);
         links.push_back(html_link(attr, decodeHtmlEntities(link)));
-        p += 1;
+        p += link.size() + 1;
     }
     return links;
 }

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -359,12 +359,6 @@ const char* strSkipTillRightAfter(const char* p, const char* s)
     return p;
 }
 
-bool isScriptTag(const char* p)
-{
-  return strncmp(p, "<script", 7) == 0
-      && (p[7] == '>' || p[7] == ' ');
-}
-
 } // unnamed namespace
 
 std::vector<html_link> generic_getLinks(const std::string& page)
@@ -378,6 +372,7 @@ std::vector<html_link> generic_getLinks(const std::string& page)
     // the current position. In a valid HTML without comments it should only
     // take values 0 or 1.
     int ltgtBalance = 0;
+    bool processingAScriptTag = false;
 
     while (*p) {
         if ( *p == '<' ) {
@@ -385,18 +380,22 @@ std::vector<html_link> generic_getLinks(const std::string& page)
             p = strSkipTillRightAfter(p, "-->");
             continue;
           }
-          if (isScriptTag(p)) {
-            p = strSkipTillRightAfter(p, "</script>");
-            continue;
-          }
-
           ++ltgtBalance;
           ++p;
+          if ( strncmp(p, "script", 6) == 0 && (p[6] == '>' || p[6] == ' ') ) {
+            processingAScriptTag = true;
+            p += 6;
+          }
           continue;
         }
         if ( *p == '>' ) {
           --ltgtBalance;
-          ++p;
+          if ( processingAScriptTag ) {
+            p = strSkipTillRightAfter(p, "</script>");
+            processingAScriptTag = false;
+          } else {
+            ++p;
+          }
           continue;
         }
 

--- a/src/tools.h
+++ b/src/tools.h
@@ -81,11 +81,12 @@ enum class UriKind : int
 class html_link
 {
 public:
-    const std::string attribute;
+    enum AttributeKind { HREF, SRC };
+    const AttributeKind attribute;
     const std::string link;
     const UriKind     uriKind;
 
-    html_link(const std::string& _attr, const std::string& _link)
+    html_link(AttributeKind _attr, const std::string& _link)
         : attribute(_attr)
         , link(_link)
         , uriKind(detectUriKind(_link))

--- a/src/zimcheck/checks.cpp
+++ b/src/zimcheck/checks.cpp
@@ -460,7 +460,7 @@ void ArticleChecker::check_external_links(zim::Item item, const LinkCollection& 
     const auto path = item.getPath();
     for (const auto &l: links)
     {
-        if (l.attribute == "src" && l.isExternalUrl())
+        if (l.attribute == html_link::SRC && l.isExternalUrl())
         {
             reporter.addMsg(MsgId::EXTERNAL_LINK, {{"link", l.link}, {"path", path}});
             if (options.quick)

--- a/test/tools-test.cpp
+++ b/test/tools-test.cpp
@@ -549,6 +549,8 @@ TEST(tools, getLinks)
   <head>
     <link src = "/css/stylesheet.css" rel="stylesheet">
     <link rel="icon" href   =    '/favicon.ico'>
+    <script defer crossorigin="anonymous" src="/js/analytics.js"></script>
+    <!-- <script src="/js/tracker.js"></script> -->
   </head>
   <body>
     <img src="../img/welcome.png">
@@ -561,14 +563,17 @@ TEST(tools, getLinks)
       &lt;img src="not_a_link_in_example_code_block.png"&gt;
     </pre>
     Powered by <a target="_blank" href="https://kiwix.org">Kiwix</a>.
+    <script src='/js/footer.js'></script>
   </body>
 </html>
 )",
       // links
       "{ src, /css/stylesheet.css }"                      "\n"
       "{ href, /favicon.ico }"                            "\n"
+      "{ src, /js/analytics.js }"                         "\n"
       "{ src, ../img/welcome.png }"                       "\n"
-      "{ href, https://kiwix.org }"
+      "{ href, https://kiwix.org }"                       "\n"
+      "{ src, /js/footer.js }"
     );
 
     EXPECT_LINKS(

--- a/test/tools-test.cpp
+++ b/test/tools-test.cpp
@@ -491,7 +491,8 @@ std::string links2Str(const std::vector<html_link>& links)
     std::ostringstream oss;
     const char* sep = "";
     for ( const auto& l : links ) {
-        oss << sep << "{ " << l.attribute << ", " << l.link << " }";
+        const char* attr = l.attribute == html_link::SRC ? "src" : "href";
+        oss << sep << "{ " << attr << ", " << l.link << " }";
         sep = "\n";
     }
     return oss.str();


### PR DESCRIPTION
Fixes #523

This PR also contains some refactoring and a small optimization.

During refactoring I noticed that `generic_getLinks()` may misbehave (run out of bounds) on invalid HTML (that ends amidst a URL being parsed as in `<html><head><script src='xyz`.

Now the question is how do we fix that? Should zimcheck report those items as a new typo of errors? Should it still report URL errors for complete URLs parsed out of such truncated HTML?