### PR TITLE
Use std::string_view for safe read-only string parameters

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -72,14 +72,14 @@ bool isDirectory(const std::string &path)
   return (filestatus.st_mode & S_IFMT) == S_IFDIR;
 }
 
-std::string getFileExtension(const std::string& path) {
+std::string getFileExtension(std::string_view path) {
     const auto posOfLastDot = path.find_last_of(".");
-    if (posOfLastDot == std::string::npos) {
+    if (posOfLastDot == std::string_view::npos) {
         return "";
     }
     const auto partAfterLastDot = path.substr(posOfLastDot + 1);
-    return partAfterLastDot.find_first_of("/\\") == std::string::npos
-         ? partAfterLastDot
+    return partAfterLastDot.find_first_of("/\\") == std::string_view::npos
+         ? std::string(partAfterLastDot)
          : "";
 }
 
@@ -265,8 +265,8 @@ std::string computeAbsolutePath(const std::string& path,
 
 
 void replaceStringInPlaceOnce(std::string& subject,
-                              const std::string& search,
-                              const std::string& replace)
+                              std::string_view search,
+                              std::string_view replace)
 {
   size_t pos = subject.find(search, 0);
   if (pos != std::string::npos) {
@@ -275,8 +275,8 @@ void replaceStringInPlaceOnce(std::string& subject,
 }
 
 void replaceStringInPlace(std::string& subject,
-                          const std::string& search,
-                          const std::string& replace)
+                          std::string_view search,
+                          std::string_view replace)
 {
   if (search.empty())
     return;
@@ -612,17 +612,17 @@ UriKind specialUriSchemeKind(const std::string& s)
 
 } // unnamed namespace
 
-UriKind html_link::detectUriKind(const std::string& input_string)
+UriKind html_link::detectUriKind(std::string_view input_string)
 {
     const auto k = input_string.find_first_of(":/?#");
-    if ( k == std::string::npos || input_string[k] != ':' ) {
+    if ( k == std::string_view::npos || input_string[k] != ':' ) {
         if ( k == 0 && input_string.substr(0, 2) == "//" )
             return UriKind::PROTOCOL_RELATIVE;
         else
             return UriKind::OTHER;
     }
 
-    const std::string raw_scheme = input_string.substr(0, k);
+    const std::string raw_scheme(input_string.substr(0, k));
     if (!isValidUriScheme(raw_scheme)) {
         return UriKind::OTHER;
     }
@@ -696,12 +696,12 @@ std::string httpRedirectHtml(const std::string& redirectUrl)
     return ss.str();
 }
 
-bool guess_is_front_article(const std::string& mimetype) {
+bool guess_is_front_article(std::string_view mimetype) {
   return ( mimetype.find("text/html") == 0
-        && mimetype.find("raw=true") == std::string::npos);
+        && mimetype.find("raw=true") == std::string_view::npos);
 }
 
-size_t getTextLength(const std::string& utf8EncodedString)
+size_t getTextLength(std::string_view utf8EncodedString)
 {
   // For some unknown reason implicite convertion from std::string to icu::StringPiece
   // is broken on Windows.

--- a/src/tools.h
+++ b/src/tools.h
@@ -23,6 +23,7 @@
 
 #include <map>
 #include <string>
+#include <string_view>
 #include <vector>
 #include <stdexcept>
 #include <sstream>
@@ -102,7 +103,7 @@ public:
         return uriKind == UriKind::OTHER;
     }
 
-    static UriKind detectUriKind(const std::string& input_string);
+    static UriKind detectUriKind(std::string_view input_string);
 };
 
 // Few helper class to help copy a item from a archive to another one.
@@ -131,7 +132,7 @@ class ItemProvider : public zim::writer::ContentProvider
 
 // Guess if the item is a front article.
 // This is not a exact science, we use the mimetype to infer it.
-bool guess_is_front_article(const std::string& mimetype);
+bool guess_is_front_article(std::string_view mimetype);
 
 
 class CopyItem : public zim::writer::Item         //Article class that will be passed to the zimwriter. Contains a zim::Article class, so it is easier to add a
@@ -180,17 +181,17 @@ std::string computeAbsolutePath(const std::string& path,
                                 const std::string& relativePath);
 bool fileExists(const std::string& path);
 bool isDirectory(const std::string &path);
-std::string getFileExtension(const std::string& path);
+std::string getFileExtension(std::string_view path);
 
 std::string base64_encode(unsigned char const* bytes_to_encode,
                           unsigned int in_len);
 
 void replaceStringInPlaceOnce(std::string& subject,
-                              const std::string& search,
-                              const std::string& replace);
+                              std::string_view search,
+                              std::string_view replace);
 void replaceStringInPlace(std::string& subject,
-                          const std::string& search,
-                          const std::string& replace);
+                          std::string_view search,
+                          std::string_view replace);
 void stripTitleInvalidChars(std::string& str);
 
 //Returns a vector of the links in a particular page. includes links under 'href' and 'src'
@@ -273,6 +274,6 @@ std::string httpRedirectHtml(const std::string& redirectUrl);
 std::string asciitolower(std::string s);
 
 // Return the count of graphemes in the provided text string
-size_t getTextLength(const std::string& utf8EncodedString);
+size_t getTextLength(std::string_view utf8EncodedString);
 
 #endif  // OPENZIM_TOOLS_H


### PR DESCRIPTION
Fixes #442
 
This change updates selected read-only function parameters from `const std::string&` to `std::string_view`. The affected functions only inspect their input during the call and do not store or return the view, so this is safe and allows callers to pass existing strings, C strings, or literals without unnecessary temporary allocations.

The change is intentionally limited. Parameters remain `std::string` when the function modifies the value, stores it, returns owned data, requires ownership or null termination, or passes it to APIs that expect a C-style string. This avoids lifetime, ownership, and compatibility problems from replacing every string indiscriminately.