### PR TITLE
Support size units in zimsplit

### DIFF
--- a/debian/man/zimsplit.1
+++ b/debian/man/zimsplit.1
@@ -11,8 +11,12 @@ ZIM file to split
 \fB\-o\fR PREFIX
 Prefix of output file parts
 .TP
-\fB\-s\fR SIZE
-Size of each file parts
+\fB\-\-size=\fISIZE\fR
+Maximum size of each part. SIZE must be a positive integer, optionally followed
+by a decimal unit (KB, MB, GB, TB, PB, or EB) or a binary unit (KiB, MiB, GiB,
+TiB, PiB, or EiB). Units are case-insensitive. A value without a unit is
+interpreted as bytes. Whitespace around SIZE and before its unit is ignored.
+SIZE must be smaller than the input file. The default is 2GiB.
 .TP
 \fB\-\-force\fR
 create ZIM parts even if it is impossible to have all part size smaller than requested

--- a/src/meson.build
+++ b/src/meson.build
@@ -26,8 +26,8 @@ executable('zimpatch', ['zimpatch.cpp', 'tools.cpp'],
   dependencies: [libzim_dep, icu_uc_dep, icu_dep],
   install: true)
 
-executable('zimsplit', ['zimsplit.cpp', 'zimsplit_size.cpp'],
-  dependencies: [libzim_dep, docopt_dep],
+executable('zimsplit', ['zimsplit.cpp', 'zimsplit_size.cpp', 'tools.cpp'],
+  dependencies: [libzim_dep, docopt_dep, icu_uc_dep, icu_dep],
   install: true)
 
 executable('zimrecreate', ['zimrecreate.cpp', 'tools.cpp'],

--- a/src/meson.build
+++ b/src/meson.build
@@ -26,7 +26,7 @@ executable('zimpatch', ['zimpatch.cpp', 'tools.cpp'],
   dependencies: [libzim_dep, icu_uc_dep, icu_dep],
   install: true)
 
-executable('zimsplit', 'zimsplit.cpp',
+executable('zimsplit', ['zimsplit.cpp', 'zimsplit_size.cpp'],
   dependencies: [libzim_dep, docopt_dep],
   install: true)
 

--- a/src/zimsplit.cpp
+++ b/src/zimsplit.cpp
@@ -27,6 +27,7 @@
 #include <docopt/docopt.h>
 
 #include "version.h"
+#include "zimsplit_size.h"
 
 #define BUFFER_SIZE 4096
 
@@ -68,6 +69,7 @@ class ZimSplitter
         ifile(fname, std::ios::binary),
         currentPartSize(0)
       {
+        validatePartSize(maxPartSize, archive.getFilesize());
         batch_buffer = new char[BUFFER_SIZE];
     }
 

--- a/src/zimsplit.cpp
+++ b/src/zimsplit.cpp
@@ -33,17 +33,6 @@
 
 const zim::size_type DEFAULT_PART_SIZE = 2147483648;
 
-uint64_t asUint64(const std::string& str) {
-    std::istringstream iss(str);
-    int64_t ret;
-    iss >> ret;
-    if(iss.fail() || !iss.eof() || ret < 0) {
-        const auto msg = "invalid uint64_t value: " + str;
-        throw std::invalid_argument(msg);
-    }
-    return ret;
-}
-
 class ZimSplitter
 {
   private:
@@ -176,12 +165,15 @@ static const char USAGE[] = R"(
     zimsplit splits smartly a ZIM file in smaller parts.
 
 Usage:
-    zimsplit [--prefix=PREFIX] [--force] [--size=N] <file>
+    zimsplit [--prefix=PREFIX] [--force] [--size=SIZE] <file>
     zimsplit --version
 
 Options:
     --prefix=PREFIX     Prefix of output file parts. Default: <file>
-    --size=N            The file size for each part. Default: 2GB
+    --size=SIZE         Maximum part size in bytes, or with a decimal unit (KB, MB, ...)
+                        or binary unit (KiB, MiB, ...). Units are case-insensitive.
+                        Whitespace around SIZE and before its unit is ignored.
+                        SIZE must be smaller than the input file. Default: 2GiB
     --force             Create zim parts even if it is impossible to have all part size smaller than requested
     -h, --help          Show this help message
     --version           Show zimsplit version.
@@ -204,7 +196,7 @@ int main(int argc, char* argv[])
 
     zim::size_type size = DEFAULT_PART_SIZE;
     if (args["--size"])
-        size = asUint64(args["--size"].asString());
+        size = parseByteSize(args["--size"].asString());
 
     // initalize app
     ZimSplitter app(args["<file>"].asString(), prefix, size);

--- a/src/zimsplit_size.cpp
+++ b/src/zimsplit_size.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 Nidhi Gahlawat.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU  General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#include "zimsplit_size.h"
+
+#include <stdexcept>
+
+namespace
+{
+
+constexpr auto partSizeTooLargeError
+    = "part size must be smaller than the input ZIM file";
+
+}  // namespace
+
+void validatePartSize(uint64_t partSize, uint64_t archiveSize)
+{
+  if (partSize >= archiveSize) {
+    throw std::invalid_argument(partSizeTooLargeError);
+  }
+}

--- a/src/zimsplit_size.cpp
+++ b/src/zimsplit_size.cpp
@@ -18,8 +18,14 @@
  */
 
 #include "zimsplit_size.h"
+#include "tools.h"
 
+#include <array>
+#include <charconv>
+#include <limits>
 #include <stdexcept>
+#include <string>
+#include <utility>
 
 namespace
 {
@@ -27,7 +33,80 @@ namespace
 constexpr auto partSizeTooLargeError
     = "part size must be smaller than the input ZIM file";
 
+void trimAsciiWhitespace(std::string& value)
+{
+  constexpr auto whitespace = " \t\n\r\f\v";
+  const auto first = value.find_first_not_of(whitespace);
+  if (first == std::string::npos) {
+    value.clear();
+    return;
+  }
+
+  const auto last = value.find_last_not_of(whitespace);
+  value = value.substr(first, last - first + 1);
+}
+
+uint64_t getUnitMultiplier(std::string unit)
+{
+  static const std::array<std::pair<std::string, uint64_t>, 14>
+      multipliers{{
+          {"", 1},
+          {"B", 1},
+          {"KB", 1000ULL},
+          {"MB", 1000ULL * 1000},
+          {"GB", 1000ULL * 1000 * 1000},
+          {"TB", 1000ULL * 1000 * 1000 * 1000},
+          {"PB", 1000ULL * 1000 * 1000 * 1000 * 1000},
+          {"EB", 1000ULL * 1000 * 1000 * 1000 * 1000 * 1000},
+          {"KiB", 1ULL << 10},
+          {"MiB", 1ULL << 20},
+          {"GiB", 1ULL << 30},
+          {"TiB", 1ULL << 40},
+          {"PiB", 1ULL << 50},
+          {"EiB", 1ULL << 60},
+      }};
+
+  const auto normalizedUnit = asciitolower(unit);
+  for (const auto& multiplier : multipliers) {
+    if (asciitolower(multiplier.first) == normalizedUnit) {
+      return multiplier.second;
+    }
+  }
+
+  throw std::invalid_argument("invalid size unit: " + unit);
+}
+
 }  // namespace
+
+uint64_t parseByteSize(std::string value)
+{
+  trimAsciiWhitespace(value);
+  if (value.empty()) {
+    throw std::invalid_argument("invalid size value: empty input");
+  }
+
+  uint64_t size = 0;
+  const char* const end = value.data() + value.size();
+  const auto parseResult = std::from_chars(value.data(), end, size);
+  if (parseResult.ec == std::errc::result_out_of_range) {
+    throw std::invalid_argument(partSizeTooLargeError);
+  }
+  if (parseResult.ec != std::errc() || parseResult.ptr == value.data()) {
+    throw std::invalid_argument("invalid size value: " + value);
+  }
+
+  std::string unit(parseResult.ptr, end);
+  trimAsciiWhitespace(unit);
+  const auto multiplier = getUnitMultiplier(unit);
+  if (size == 0) {
+    throw std::invalid_argument("part size must be positive: " + value);
+  }
+  if (size > std::numeric_limits<uint64_t>::max() / multiplier) {
+    throw std::invalid_argument(partSizeTooLargeError);
+  }
+
+  return size * multiplier;
+}
 
 void validatePartSize(uint64_t partSize, uint64_t archiveSize)
 {

--- a/src/zimsplit_size.h
+++ b/src/zimsplit_size.h
@@ -21,7 +21,9 @@
 #define OPENZIM_ZIMSPLIT_SIZE_H
 
 #include <cstdint>
+#include <string>
 
+uint64_t parseByteSize(std::string value);
 void validatePartSize(uint64_t partSize, uint64_t archiveSize);
 
 #endif

--- a/src/zimsplit_size.h
+++ b/src/zimsplit_size.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2026 Nidhi Gahlawat.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU  General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#ifndef OPENZIM_ZIMSPLIT_SIZE_H
+#define OPENZIM_ZIMSPLIT_SIZE_H
+
+#include <cstdint>
+
+void validatePartSize(uint64_t partSize, uint64_t archiveSize);
+
+#endif

--- a/test/meson.build
+++ b/test/meson.build
@@ -4,7 +4,8 @@ gtest_dep = dependency('gtest', main:true, fallback:['gtest', 'gtest_main_dep'],
 test_deps = [gtest_dep, libzim_dep, icu_uc_dep, icu_dep, docopt_dep]
 tests = [
     'metadata-test',
-    'zimcheck-test'
+    'zimcheck-test',
+    'zimsplit-test'
 ]
 
 if with_writer
@@ -22,6 +23,7 @@ zimwriter_srcs = [  '../src/zimwriterfs/tools.cpp',
 tests_src_map = { 'zimcheck-test' : ['../src/zimcheck/zimcheck.cpp', '../src/zimcheck/checks.cpp',  '../src/zimcheck/json_tools.cpp', '../src/tools.cpp', '../src/metadata.cpp'],
                   'tools-test' : zimwriter_srcs,
                   'metadata-test' : ['../src/metadata.cpp', '../src/tools.cpp'],
+                  'zimsplit-test' : ['../src/zimsplit_size.cpp'],
                   'zimwriterfs-zimcreatorfs' : zimwriter_srcs }
 
 if gtest_dep.found() and not meson.is_cross_build()

--- a/test/meson.build
+++ b/test/meson.build
@@ -23,7 +23,7 @@ zimwriter_srcs = [  '../src/zimwriterfs/tools.cpp',
 tests_src_map = { 'zimcheck-test' : ['../src/zimcheck/zimcheck.cpp', '../src/zimcheck/checks.cpp',  '../src/zimcheck/json_tools.cpp', '../src/tools.cpp', '../src/metadata.cpp'],
                   'tools-test' : zimwriter_srcs,
                   'metadata-test' : ['../src/metadata.cpp', '../src/tools.cpp'],
-                  'zimsplit-test' : ['../src/zimsplit_size.cpp'],
+                  'zimsplit-test' : ['../src/zimsplit_size.cpp', '../src/tools.cpp'],
                   'zimwriterfs-zimcreatorfs' : zimwriter_srcs }
 
 if gtest_dep.found() and not meson.is_cross_build()

--- a/test/zimsplit-test.cpp
+++ b/test/zimsplit-test.cpp
@@ -1,0 +1,31 @@
+#include <stdexcept>
+
+#include "../src/zimsplit_size.h"
+#include "gtest/gtest.h"
+
+namespace
+{
+
+#define EXPECT_INVALID_ARG_ERROR(statement, expectedError)                      \
+  do {                                                                         \
+    try {                                                                      \
+      statement;                                                               \
+      FAIL() << "Expected std::invalid_argument";                              \
+    } catch (const std::invalid_argument& error) {                              \
+      EXPECT_STREQ(error.what(), expectedError);                                \
+    }                                                                          \
+  } while (false)
+
+constexpr auto TOO_LARGE_PART_SIZE_ERROR
+    = "part size must be smaller than the input ZIM file";
+
+}  // namespace
+
+TEST(ZimSplitSize, ValidatesPartSizeAgainstArchive)
+{
+  EXPECT_NO_THROW(validatePartSize(99, 100));
+  EXPECT_INVALID_ARG_ERROR(validatePartSize(100, 100),
+                           TOO_LARGE_PART_SIZE_ERROR);
+  EXPECT_INVALID_ARG_ERROR(validatePartSize(101, 100),
+                           TOO_LARGE_PART_SIZE_ERROR);
+}

--- a/test/zimsplit-test.cpp
+++ b/test/zimsplit-test.cpp
@@ -1,3 +1,5 @@
+#include <cstdint>
+#include <limits>
 #include <stdexcept>
 
 #include "../src/zimsplit_size.h"
@@ -20,6 +22,84 @@ constexpr auto TOO_LARGE_PART_SIZE_ERROR
     = "part size must be smaller than the input ZIM file";
 
 }  // namespace
+
+TEST(ZimSplitSize, ParsesBytes)
+{
+  EXPECT_EQ(parseByteSize("1"), 1U);
+  EXPECT_EQ(parseByteSize("0001"), 1U);
+  EXPECT_EQ(parseByteSize("2147483648"), 2147483648ULL);
+  EXPECT_EQ(parseByteSize("42B"), 42U);
+  EXPECT_EQ(parseByteSize("18446744073709551615"),
+            std::numeric_limits<uint64_t>::max());
+  EXPECT_EQ(parseByteSize("18446744073709551615b"),
+            std::numeric_limits<uint64_t>::max());
+}
+
+TEST(ZimSplitSize, ParsesDecimalUnits)
+{
+  EXPECT_EQ(parseByteSize("2KB"), 2000U);
+  EXPECT_EQ(parseByteSize("2kb"), 2000U);
+  EXPECT_EQ(parseByteSize("2kB"), 2000U);
+  EXPECT_EQ(parseByteSize(" 1 GB "), 1000000000U);
+  EXPECT_EQ(parseByteSize("1GB "), 1000000000U);
+  EXPECT_EQ(parseByteSize("    1    GB   "), 1000000000U);
+  EXPECT_EQ(parseByteSize("3MB"), 3000000U);
+  EXPECT_EQ(parseByteSize("4GB"), 4000000000ULL);
+  EXPECT_EQ(parseByteSize("1TB"), 1000000000000ULL);
+  EXPECT_EQ(parseByteSize("1PB"), 1000000000000000ULL);
+  EXPECT_EQ(parseByteSize("1EB"), 1000000000000000000ULL);
+  EXPECT_EQ(parseByteSize("18EB"), 18000000000000000000ULL);
+}
+
+TEST(ZimSplitSize, ParsesBinaryUnits)
+{
+  EXPECT_EQ(parseByteSize("2KiB"), 2048U);
+  EXPECT_EQ(parseByteSize("2kib"), 2048U);
+  EXPECT_EQ(parseByteSize("2KIB"), 2048U);
+  EXPECT_EQ(parseByteSize("2kIb"), 2048U);
+  EXPECT_EQ(parseByteSize("3MiB"), 3145728U);
+  EXPECT_EQ(parseByteSize("4GiB"), 4294967296ULL);
+  EXPECT_EQ(parseByteSize("1TiB"), 1099511627776ULL);
+  EXPECT_EQ(parseByteSize("1PiB"), 1125899906842624ULL);
+  EXPECT_EQ(parseByteSize("1EiB"), 1152921504606846976ULL);
+  EXPECT_EQ(parseByteSize("15EiB"), 17293822569102704640ULL);
+}
+
+TEST(ZimSplitSize, RejectsZero)
+{
+  EXPECT_INVALID_ARG_ERROR(parseByteSize("0"), "part size must be positive: 0");
+  EXPECT_INVALID_ARG_ERROR(parseByteSize("0GB"),
+                           "part size must be positive: 0GB");
+}
+
+TEST(ZimSplitSize, RejectsMalformedValues)
+{
+  EXPECT_INVALID_ARG_ERROR(parseByteSize(""),
+                           "invalid size value: empty input");
+  EXPECT_INVALID_ARG_ERROR(parseByteSize("   "),
+                           "invalid size value: empty input");
+  EXPECT_INVALID_ARG_ERROR(parseByteSize("-1"), "invalid size value: -1");
+  EXPECT_INVALID_ARG_ERROR(parseByteSize("+1"), "invalid size value: +1");
+  EXPECT_INVALID_ARG_ERROR(parseByteSize("1.5GB"),
+                           "invalid size unit: .5GB");
+  EXPECT_INVALID_ARG_ERROR(parseByteSize("1 G B"), "invalid size unit: G B");
+  EXPECT_INVALID_ARG_ERROR(parseByteSize("1GBjunk"),
+                           "invalid size unit: GBjunk");
+  EXPECT_INVALID_ARG_ERROR(parseByteSize("1e3"), "invalid size unit: e3");
+  EXPECT_INVALID_ARG_ERROR(parseByteSize("GB"), "invalid size value: GB");
+  EXPECT_INVALID_ARG_ERROR(parseByteSize("1K"), "invalid size unit: K");
+  EXPECT_INVALID_ARG_ERROR(parseByteSize("1Ki"), "invalid size unit: Ki");
+}
+
+TEST(ZimSplitSize, RejectsOverflow)
+{
+  EXPECT_INVALID_ARG_ERROR(parseByteSize("18446744073709551616"),
+                           TOO_LARGE_PART_SIZE_ERROR);
+  EXPECT_INVALID_ARG_ERROR(parseByteSize("19EB"),
+                           TOO_LARGE_PART_SIZE_ERROR);
+  EXPECT_INVALID_ARG_ERROR(parseByteSize("16EiB"),
+                           TOO_LARGE_PART_SIZE_ERROR);
+}
 
 TEST(ZimSplitSize, ValidatesPartSizeAgainstArchive)
 {


### PR DESCRIPTION
## Summary

- Preserve unitless `--size` values as bytes.
- Support decimal units (`KB`, `MB`, ..., `EB`) and binary units (`KiB`, `MiB`, ..., `EiB`).
- Match units case-insensitively and ignore whitespace around the size and before its unit.
- Reject zero, malformed values, and values that overflow `uint64_t`.
- Require the requested part size to be smaller than the input ZIM file before creating output files.
- Update CLI help, the zimsplit man page, and focused parser/validation tests.

## Commit structure

1. `Reject oversized zimsplit part sizes`
2. `Support size units in zimsplit`

## Testing

- `meson test -C build --print-errorlogs` (all 5 test targets pass)
- Focused `zimsplit-test` under AddressSanitizer and UndefinedBehaviorSanitizer
- Coverage build: `src/zimsplit_size.cpp` has 100% line coverage
- Manual CLI check with `--size="    1    GB   "` reaches source-size validation

Closes #524